### PR TITLE
feat: calculate area of polygons

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -230,6 +230,11 @@ function getFeatures(coord) {
     .catch((error) => console.log(error));
 }
 
+outlineSource.on("addfeature", function () {
+  let unioned_features = outlineSource.getFeatures();
+  console.log("total area", formatArea(unioned_features[0]["values_"].geometry));
+});
+
 /**
  * Helper function to return OS Features URL with encoded parameters
  * @param {object} params - The parameters object to be encoded

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,7 @@ class DrawModeControl extends Control {
   }
 
   startDrawing() {
-    // Don't show feature outlines when drawing, underlying features still logged to console
+    // Don't show feature outlines when drawing, underlying features still listening for clicks and logged to console
     map.removeLayer(outlineLayer);
 
     const modify = new Modify({ source: drawingSource });
@@ -57,9 +57,8 @@ class DrawModeControl extends Control {
 
     addInteractions();
 
-    // 'addFeature' ensures getFeatures() isn't empty, which 'drawend' does not
-    // TODO recalculate when an existing feature is modified
-    drawingSource.on("addfeature", function () {
+    // 'change' ensures getFeatures() isn't empty and listens for modifications; 'drawend' does not
+    drawingSource.on("change", function () {
       let sketches = drawingSource.getFeatures();
       let last_sketch_geom = sketches[sketches.length - 1]["values_"].geometry;
 
@@ -186,7 +185,7 @@ function getFeatures(coord) {
             "EPSG:4326",
             "EPSG:3857"
           )
-        )
+        ) // for debugging only so we can check 'total area' log is summing correctly
       );
 
       if (!data.features.length) return;
@@ -232,7 +231,9 @@ function getFeatures(coord) {
 
 outlineSource.on("addfeature", function () {
   let unioned_features = outlineSource.getFeatures();
-  console.log("total area", formatArea(unioned_features[0]["values_"].geometry));
+  let unioned_geom = unioned_features[0]["values_"].geometry;
+
+  console.log("total area", formatArea(unioned_geom));
 });
 
 /**


### PR DESCRIPTION
- [x] for custom drawings
- [x] for "modified" drawings
- [x] for features clicked
- [x] for unioned features clicked

just console logging the area measurements for now until we make more design decisions! open layers ["measure" examples](https://openlayers.org/en/latest/examples/measure.html) use dynamic tooltips directly on the map, while planx currently renders total area outside of map container.