### PR TITLE
feat: reset control to clear drawing

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Map</title>
-    <script type="module" src="src/my-map.ts"></script>
+    <script type="module" src="./src/my-map.ts"></script>
     <!-- OS vector tile source specifies fonts in .pbf format, which OpenLayers can't load, so make them available directly  -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -1,5 +1,6 @@
 import { css, customElement, html, LitElement, property } from "lit-element";
 import stylefunction from "ol-mapbox-style/dist/stylefunction";
+import { Control } from "ol/control";
 import { Draw, Modify, Snap } from "ol/interaction";
 import Map from "ol/Map";
 import { fromLonLat, transformExtent } from "ol/proj";
@@ -22,6 +23,10 @@ export class MyMap extends LitElement {
       opacity: 0;
       transition: opacity 0.25s;
       overflow: hidden;
+    }
+    .reset-control {
+      top: 70px;
+      left: .5em;
     }
   `;
 
@@ -85,6 +90,29 @@ export class MyMap extends LitElement {
         zoom: this.zoom,
       }),
     });
+
+    const button = document.createElement('button');
+    button.innerHTML = '↻';
+
+    const handleReset = () => {
+      map.getView().setCenter(fromLonLat([this.longitude, this.latitude]));
+      map.getView().setZoom(this.zoom);
+
+      if (drawingSource) {
+        drawingSource.clear();
+      }
+    };
+
+    button.addEventListener('click', handleReset, false);
+
+    const element = document.createElement('div');
+    element.className = 'reset-control ol-unselectable ol-control';
+    element.appendChild(button);
+
+    var ResetControl = new Control({
+      element: element
+    });
+    map.addControl(ResetControl);
 
     if (this.drawMode) {
       map.addLayer(drawingLayer);

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -88,11 +88,14 @@ export class MyMap extends LitElement {
         maxZoom: this.maxZoom,
         center: fromLonLat([this.longitude, this.latitude]),
         zoom: this.zoom,
+        enableRotation: false,
       }),
     });
 
+    // add a custom control below default zoom
     const button = document.createElement('button');
     button.innerHTML = '↻';
+    button.title = "Reset view & erase any drawings";
 
     const handleReset = () => {
       map.getView().setCenter(fromLonLat([this.longitude, this.latitude]));
@@ -109,9 +112,7 @@ export class MyMap extends LitElement {
     element.className = 'reset-control ol-unselectable ol-control';
     element.appendChild(button);
 
-    var ResetControl = new Control({
-      element: element
-    });
+    var ResetControl = new Control({ element: element });
     map.addControl(ResetControl);
 
     if (this.drawMode) {


### PR DESCRIPTION
custom control button to reset to original zoom & center and clear any drawn features if they exist.

also disabling rotation which should fix #6. 

maybe this should be dispatching an event like #13 though? 