### PR TITLE
chore: draw styles cleanup

### DIFF
--- a/src/draw.ts
+++ b/src/draw.ts
@@ -36,7 +36,7 @@ export const draw = new Draw({
     stroke: new Stroke({
       color: "#ff0000",
       width: 3,
-      lineDash: [4, 8],
+      lineDash: [2, 8],
     }),
     fill: new Fill({
       color: "rgba(255, 255, 255, 0.2)",

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -10,29 +10,52 @@ const redLineStroke = new Stroke({
   width: 3,
 });
 
+const drawingPointer = new CircleStyle({
+  radius: 6,
+  fill: new Fill({
+    color: "#ff0000",
+  }),
+});
+
 export const drawingSource = new VectorSource();
 
 export const drawingLayer = new VectorLayer({
   source: drawingSource,
   style: new Style({
     fill: new Fill({
-      color: "rgba(255, 255, 255, 0.2)",
+      color: "rgba(255, 255, 255, 0.4)",
     }),
     stroke: redLineStroke,
-    image: new CircleStyle({
-      radius: 5,
-      fill: new Fill({
-        color: "#c7ea46",
-      }),
-    }),
   }),
 });
 
-export const draw = new Draw({ source: drawingSource, type: "Polygon" });
+export const draw = new Draw({
+  source: drawingSource,
+  type: "Polygon",
+  style: new Style({
+    stroke: new Stroke({
+      color: "#ff0000",
+      width: 3,
+      lineDash: [4, 8],
+    }),
+    fill: new Fill({
+      color: "rgba(255, 255, 255, 0.2)",
+    }),
+    image: drawingPointer,
+  }),
+});
 
-export const snap = new Snap({ source: drawingSource, pixelTolerance: 5 });
+export const snap = new Snap({
+  source: drawingSource,
+  pixelTolerance: 5,
+});
 
-export const modify = new Modify({ source: drawingSource });
+export const modify = new Modify({
+  source: drawingSource,
+  style: new Style({
+    image: drawingPointer,
+  }),
+});
 
 // calculate and format the area of a polygon
 export function formatArea(polygon: Geometry) {

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -6,7 +6,14 @@ import { fromLonLat, transformExtent } from "ol/proj";
 import View from "ol/View";
 import { last } from "rambda";
 
-import { draw, drawingLayer, drawingSource, formatArea, modify, snap } from "./draw";
+import {
+  draw,
+  drawingLayer,
+  drawingSource,
+  formatArea,
+  modify,
+  snap,
+} from "./draw";
 import { osVectorTileBaseMap, rasterBaseMap } from "./os-layers";
 
 @customElement("my-map")
@@ -27,7 +34,7 @@ export class MyMap extends LitElement {
     }
     .reset-control {
       top: 70px;
-      left: .5em;
+      left: 0.5em;
     }
     #area {
       position: absolute;
@@ -84,26 +91,26 @@ export class MyMap extends LitElement {
       }),
     });
 
-    // add a custom control below default zoom
-    const button = document.createElement('button');
-    button.innerHTML = '↻';
+    // add a custom 'reset' control below zoom
+    const button = document.createElement("button");
+    button.innerHTML = "↻";
     button.title = "Reset view";
 
     const handleReset = () => {
       map.getView().setCenter(fromLonLat([this.longitude, this.latitude]));
       map.getView().setZoom(this.zoom);
 
-      if (this.drawMode && drawingSource) {
+      if (this.drawMode) {
         drawingSource.clear();
         map.addInteraction(draw);
         map.addInteraction(snap);
       }
     };
 
-    button.addEventListener('click', handleReset, false);
+    button.addEventListener("click", handleReset, false);
 
-    const element = document.createElement('div');
-    element.className = 'reset-control ol-unselectable ol-control';
+    const element = document.createElement("div");
+    element.className = "reset-control ol-unselectable ol-control";
     element.appendChild(button);
 
     var ResetControl = new Control({ element: element });
@@ -111,11 +118,11 @@ export class MyMap extends LitElement {
 
     // define cursors for dragging/panning and moving
     map.on("pointerdrag", () => {
-      map.getViewport().style.cursor = "-webkit-grabbing";
+      map.getViewport().style.cursor = "grabbing";
     });
 
     map.on("pointermove", () => {
-      map.getViewport().style.cursor = "-webkit-grab";
+      map.getViewport().style.cursor = "grab";
     });
 
     if (this.drawMode) {
@@ -129,7 +136,6 @@ export class MyMap extends LitElement {
       drawingSource.on("change", () => {
         const sketches = drawingSource.getFeatures();
 
-        // account for drawingSource.clear() in handleReset
         if (sketches.length > 0) {
           const lastSketchGeom = last(sketches).getGeometry();
 
@@ -139,7 +145,7 @@ export class MyMap extends LitElement {
               featureProjection: "EPSG:3857",
             })
           );
-  
+
           this.dispatch("areaChange", formatArea(lastSketchGeom));
 
           // limit to drawing a single polygon

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -87,13 +87,13 @@ export class MyMap extends LitElement {
     // add a custom control below default zoom
     const button = document.createElement('button');
     button.innerHTML = '↻';
-    button.title = "Reset view & erase any drawings";
+    button.title = "Reset view";
 
     const handleReset = () => {
       map.getView().setCenter(fromLonLat([this.longitude, this.latitude]));
       map.getView().setZoom(this.zoom);
 
-      if (drawingSource) {
+      if (this.drawMode && drawingSource) {
         drawingSource.clear();
         map.addInteraction(draw);
         map.addInteraction(snap);
@@ -109,6 +109,15 @@ export class MyMap extends LitElement {
     var ResetControl = new Control({ element: element });
     map.addControl(ResetControl);
 
+    // define cursors for dragging/panning and moving
+    map.on("pointerdrag", () => {
+      map.getViewport().style.cursor = "-webkit-grabbing";
+    });
+
+    map.on("pointermove", () => {
+      map.getViewport().style.cursor = "-webkit-grab";
+    });
+
     if (this.drawMode) {
       map.addLayer(drawingLayer);
 
@@ -120,7 +129,7 @@ export class MyMap extends LitElement {
       drawingSource.on("change", () => {
         const sketches = drawingSource.getFeatures();
 
-        // account for dataSource.clear() on "reset" control
+        // account for drawingSource.clear() in handleReset
         if (sketches.length > 0) {
           const lastSketchGeom = last(sketches).getGeometry();
 

--- a/src/os-layers.ts
+++ b/src/os-layers.ts
@@ -53,6 +53,6 @@ async function applyVectorTileStyle() {
   } catch (error) {
     console.log(error);
   }
-};
+}
 
 applyVectorTileStyle();


### PR DESCRIPTION
- Red dashed line while drawing in-progress, solid red when closed or modifying (we'll save "blue lines" for feature selection this way, which seems consistent with how people have been talking about address outlines)
- Simple cursor distinction for moving versus panning/dragging (click+hold). At one point there was an "accessibility" card that asked for the cursor to be a 'pencil' if in draw mode, but I think that's a bit harder & lower prio - so keeping the red circle for now which I'd also argue is maybe still best for clearing showing where your points will be placed
- Prettier formatting