### PR TITLE
chore: formatArea as shared util, optionally calculate in hectares

### DIFF
--- a/src/draw.ts
+++ b/src/draw.ts
@@ -1,8 +1,6 @@
-import Geometry from "ol/geom/Geometry";
 import { Draw, Modify, Snap } from "ol/interaction";
 import { Vector as VectorLayer } from "ol/layer";
 import { Vector as VectorSource } from "ol/source";
-import { getArea } from "ol/sphere";
 import { Circle as CircleStyle, Fill, Stroke, Style } from "ol/style";
 
 const redLineStroke = new Stroke({
@@ -33,15 +31,3 @@ export const draw = new Draw({ source: drawingSource, type: "Polygon" });
 export const snap = new Snap({ source: drawingSource, pixelTolerance: 5 });
 
 export const modify = new Modify({ source: drawingSource });
-
-// calculate and format the area of a polygon
-export function formatArea(polygon: Geometry) {
-  const area = getArea(polygon);
-  let output;
-  if (area > 10000) {
-    output = Math.round((area / 1000000) * 100) / 100 + " " + "km<sup>2</sup>";
-  } else {
-    output = Math.round(area * 100) / 100 + " " + "m<sup>2</sup>";
-  }
-  return output;
-}

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -6,8 +6,9 @@ import { fromLonLat, transformExtent } from "ol/proj";
 import View from "ol/View";
 import { last } from "rambda";
 
-import { draw, drawingLayer, drawingSource, formatArea, modify, snap } from "./draw";
+import { draw, drawingLayer, drawingSource, modify, snap } from "./draw";
 import { osVectorTileBaseMap, rasterBaseMap } from "./os-layers";
+import { formatArea } from "./utils";
 
 @customElement("my-map")
 export class MyMap extends LitElement {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,24 @@
+import Geometry from "ol/geom/Geometry";
+import { getArea } from "ol/sphere";
+
+/**
+ * Calculate & format the area of a polygon
+ * @param polygon
+ * @param units - defaults to square metres, or supports "ha" for hectares
+ * @returns - a string with html tags
+ */
+export function formatArea(polygon: Geometry, units: String = "m2") {
+  const area = getArea(polygon);
+
+  const squareMetres = Math.round(area * 100) / 100;
+  const hectares = squareMetres / 10000; // 0.0001 hectares in 1 square metre
+
+  let output;
+  if (units === "m2") {
+    output = squareMetres + " m<sup>2</sup>";
+  } else if (units === "ha") {
+    output = hectares + " ha";
+  }
+
+  return output;
+}


### PR DESCRIPTION
quick clean up that'll make it easier to share formatArea function between drawings and other polygons (rendered geojson or selected features)

adding optional units param for hectares while it's fresh, but won't close that related Trello card as it's framed as ability to toggle between units in the UI