### PR TITLE
feat: display a static polygon if geojson provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,28 @@ An OpenLayers-powered Web Component map for tasks related to planning permission
 
 [CodeSandbox](https://codesandbox.io/s/confident-benz-rr0s9?file=/index.html)
 
+### Example: load static geojson
+
+Relevant configurable properties & their default values: 
+```js
+@property({ type: Object })
+geojsonData = {
+  type: "FeatureCollection",
+  features: [],
+};
+
+@property({ type: String })
+geojsonColor = "#ff0000";
+
+@property({ type: Number })
+geojsonBuffer = 15;
+```
+
+`geojsonData` is required. The default is an empty geojson object so that we can initialize a VectorLayer & VectorSource regardless. This is currently optimized for geojson containing a single polygon feature.
+
+`geojsonColor` & `geojsonBuffer` are optional style properties. Color sets the stroke of the displayed data and buffer is used to fit the map view to the extent of the geojson features. `geojsonBuffer` corresponds to "value" param in OL documentation (here)[https://openlayers.org/en/latest/apidoc/module-ol_extent.html].
+
+
 ## Running Locally
 
 - Rename `.env.example` to `.env.local` and replace the values

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ geojsonBuffer = 15;
 
 `geojsonData` is required. The default is an empty geojson object so that we can initialize a VectorLayer & VectorSource regardless. This is currently optimized for geojson containing a single polygon feature.
 
-`geojsonColor` & `geojsonBuffer` are optional style properties. Color sets the stroke of the displayed data and buffer is used to fit the map view to the extent of the geojson features. `geojsonBuffer` corresponds to "value" param in OL documentation (here)[https://openlayers.org/en/latest/apidoc/module-ol_extent.html].
+`geojsonColor` & `geojsonBuffer` are optional style properties. Color sets the stroke of the displayed data and buffer is used to fit the map view to the extent of the geojson features. `geojsonBuffer` corresponds to "value" param in OL documentation [here](https://openlayers.org/en/latest/apidoc/module-ol_extent.html).
 
 
 ## Running Locally

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -1,4 +1,5 @@
 import Geometry from "ol/geom/Geometry";
+import { Draw, Modify, Snap } from "ol/interaction";
 import { Vector as VectorLayer } from "ol/layer";
 import { Vector as VectorSource } from "ol/source";
 import { getArea } from "ol/sphere";
@@ -26,6 +27,12 @@ export const drawingLayer = new VectorLayer({
     }),
   }),
 });
+
+export const draw = new Draw({ source: drawingSource, type: "Polygon" });
+
+export const snap = new Snap({ source: drawingSource, pixelTolerance: 5 });
+
+export const modify = new Modify({ source: drawingSource });
 
 // calculate and format the area of a polygon
 export function formatArea(polygon: Geometry) {

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -71,6 +71,9 @@ export class MyMap extends LitElement {
   @property({ type: String })
   geojsonColor = "#ff0000";
 
+  @property({ type: Number })
+  geojsonBuffer = 12;
+
   private useVectorTiles =
     Boolean(import.meta.env.VITE_APP_ORDNANCE_SURVEY_KEY) &&
     osVectorTileBaseMap;
@@ -106,7 +109,7 @@ export class MyMap extends LitElement {
     const handleReset = () => {
       if (this.geojsonData.features.length > 0) {
         const extent = outlineSource.getExtent();
-        map.getView().fit(buffer(extent, 12)); // overrides default zoom & center
+        map.getView().fit(buffer(extent, this.geojsonBuffer)); // overrides default zoom & center
       } else {
         map.getView().setCenter(fromLonLat([this.longitude, this.latitude]));
         map.getView().setZoom(this.zoom);
@@ -159,7 +162,7 @@ export class MyMap extends LitElement {
     if (this.geojsonData.features.length > 0) {
       // fit map to extent of features
       const extent = outlineSource.getExtent();
-      map.getView().fit(buffer(extent, 12)); // overrides default zoom & center
+      map.getView().fit(buffer(extent, this.geojsonBuffer)); // overrides default zoom & center
 
       // log total area of feature (assumes geojson is a single polygon)
       const data = outlineSource.getFeatures()[0].getGeometry();


### PR DESCRIPTION
- adds an outlineLayer that is by default empty, but can read & display features from a geojson data object if provided
- optional `geojsonColor` param to specify a custom hex code for the outline (defaults to red)
- if geojson is provided, re-fit the map view based on the extent of the features overriding default zoom & center. reset control will reference the same extent. optional `geojsonBuffer` param to control how much the extent should be buffered
- calculates & logs the total area of the geojson feature if provided

open questions:
- currently allowing drawMode true & static polygon to co-exist because I think this will satisfy BOP's use case of displaying the current site plan & then drawing an amendment on the same map - does that sound right?
- you can currently add any type of geojson (point, line, polygon, many polygons!) - i think it's fair to assume we ONLY have a single polygon use case for now, but might be good to have more explicit/restrictive "geojsonData" property type in future

example `index.html` implementation (Object type properties still feel a bit weird in html! here's [LitElement's docs](https://lit-element.polymer-project.org/guide/properties#conversion-type)):
```html
...
<body>
    <my-map zoom="18" />
    <script>
      const map = document.querySelector("my-map");
      map.geojsonData = {
        "type": "FeatureCollection",
        "features": [
          {
            "type": "Feature",
            "properties": {},
            "geometry": {
              "type": "Polygon",
              "coordinates": [
                [
                  [
                    -0.1282256841659546,
                    51.507540479227096
                  ],
                  [
                    -0.12817740440368652,
                    51.50719323477933
                  ],
                  [
                    -0.12763023376464844,
                    51.50703630613181
                  ],
                  [
                    -0.12700796127319336,
                    51.50730341840034
                  ],
                  [
                    -0.12736737728118894,
                    51.50777753882043
                  ],
                  [
                    -0.1282256841659546,
                    51.507540479227096
                  ]
                ]
              ]
            }
          }
        ]
      };
```