### PR TITLE
feat: query & display features that intersect with lon,lat

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,36 @@ An OpenLayers-powered Web Component map for tasks related to planning permission
 
 [CodeSandbox](https://codesandbox.io/s/confident-benz-rr0s9?file=/index.html)
 
+### Example: highlight features that intersect with a given coordinate
+
+Requires access to the Ordnance Survey Features API. Sign up for a key here: https://osdatahub.os.uk/plans. 
+
+Relevant configurable properties & their default values: 
+```js
+@property({ type: Number })
+latitude = 51.507351;
+
+@property({ type: Number })
+longitude = -0.127758;
+
+@property({ type: Boolean })
+showFeaturesAtPoint = false;
+
+@property({ type: String })
+featureColor = "#0000ff";
+
+@property({ type: Number })
+featureBuffer = 40;
+```
+
+Set `showFeaturesAtPoint` to true. `latitude` and `longitude` are required and used to query the OS Features API for features that contain this point.
+
+`featureColor` & `featureBuffer` are optional style properties. Color sets the stroke of the displayed data and buffer is used to fit the map view to the extent of the features. `featureBuffer` corresponds to "value" param in OL documentation [here](https://openlayers.org/en/latest/apidoc/module-ol_extent.html).
+
+```html
+<my-map latitude="51.4858363" longitude="-0.0761246" showFeaturesAtPoint featureColor="#8a2be2" />
+```
+
 ## Running Locally
 
 - Rename `.env.example` to `.env.local` and replace the values

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -66,6 +66,9 @@ export class MyMap extends LitElement {
   @property({ type: String })
   featureColor = "#0000ff";
 
+  @property({ type: Number })
+  featureBuffer = 40;
+
   private useVectorTiles =
     Boolean(import.meta.env.VITE_APP_ORDNANCE_SURVEY_KEY) &&
     osVectorTileBaseMap;
@@ -99,8 +102,13 @@ export class MyMap extends LitElement {
     button.title = "Reset view";
 
     const handleReset = () => {
-      map.getView().setCenter(fromLonLat([this.longitude, this.latitude]));
-      map.getView().setZoom(this.zoom);
+      if (this.showFeaturesAtPoint) {
+        const extent = featureSource.getExtent();
+        map.getView().fit(buffer(extent, this.featureBuffer));
+      } else {
+        map.getView().setCenter(fromLonLat([this.longitude, this.latitude]));
+        map.getView().setZoom(this.zoom);
+      }
 
       if (this.drawMode) {
         drawingSource.clear();
@@ -171,7 +179,7 @@ export class MyMap extends LitElement {
         ) {
           // fit map to extent of features
           const extent = featureSource.getExtent();
-          map.getView().fit(buffer(extent, 40)); // XXX: tricky to set buffer number here since outlined feature may be one bldg on whole site
+          map.getView().fit(buffer(extent, this.featureBuffer));
 
           // log total area of feature
           const data = featureSource.getFeatures()[0].getGeometry();

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -7,6 +7,7 @@ import View from "ol/View";
 import { last } from "rambda";
 
 import { draw, drawingLayer, drawingSource, modify, snap } from "./draw";
+import { featureLayer, featureSource, getFeatures } from "./os-features";
 import { osVectorTileBaseMap, rasterBaseMap } from "./os-layers";
 import { formatArea } from "./utils";
 
@@ -57,6 +58,12 @@ export class MyMap extends LitElement {
 
   @property({ type: Boolean })
   drawMode = true;
+
+  @property({ type: Boolean })
+  showFeaturesAtPoint = true;
+
+  @property({ type: String })
+  featureColor = "#0000ff";
 
   private useVectorTiles =
     Boolean(import.meta.env.VITE_APP_ORDNANCE_SURVEY_KEY) &&
@@ -147,6 +154,15 @@ export class MyMap extends LitElement {
           map.removeInteraction(snap);
         }
       });
+    }
+
+    if (this.showFeaturesAtPoint) {
+      getFeatures(fromLonLat([this.longitude, this.latitude]));
+      
+      map.addLayer(featureLayer);
+
+      const featureExtent = featureSource.getExtent();
+      console.log(featureExtent);
     }
 
     // XXX: force re-render for safari due to it thinking map is 0 height on load

--- a/src/os-features.ts
+++ b/src/os-features.ts
@@ -8,15 +8,17 @@ const featureServiceUrl = "https://api.os.uk/features/v1/wfs";
 
 export const featureSource = new VectorSource();
 
-export const featureLayer = new VectorLayer({
-  source: featureSource,
-  style: new Style({
-    stroke: new Stroke({
-      width: 3,
-      color: "#0000ff",
+export function createFeatureLayer(color: string) {
+  return new VectorLayer({
+    source: featureSource,
+    style: new Style({
+      stroke: new Stroke({
+        width: 3,
+        color: color,
+      }),
     }),
-  }),
-});
+  });
+}
 
 /**
  * Create an OGC XML filter parameter value which will select the TopographicArea
@@ -55,7 +57,7 @@ export function getFeatures(coord: Array<number>) {
   fetch(getUrl(wfsParams))
     .then((response) => response.json())
     .then((data) => {
-      console.log("features:", data);
+      console.log("features at this point:", data);
 
       if (!data.features.length) return;
 

--- a/src/os-features.ts
+++ b/src/os-features.ts
@@ -1,0 +1,92 @@
+import { GeoJSON } from "ol/format";
+import { Vector as VectorLayer } from "ol/layer";
+import { toLonLat } from "ol/proj";
+import { Vector as VectorSource } from "ol/source";
+import { Stroke, Style } from "ol/style";
+
+const featureServiceUrl = "https://api.os.uk/features/v1/wfs";
+
+export const featureSource = new VectorSource();
+
+export const featureLayer = new VectorLayer({
+  source: featureSource,
+  style: new Style({
+    stroke: new Stroke({
+      width: 3,
+      color: "#0000ff",
+    }),
+  }),
+});
+
+/**
+ * Create an OGC XML filter parameter value which will select the TopographicArea
+ *   features containing the coordinates of the provided point
+ * @param coord - xy coordinate
+ */
+export function getFeatures(coord: Array<number>) {
+  const xml = `
+    <ogc:Filter>
+      <ogc:Contains>
+      <ogc:PropertyName>SHAPE</ogc:PropertyName>
+        <gml:Point srsName="urn:ogc:def:crs:EPSG::4326">
+          <gml:coordinates>${toLonLat(coord)
+            .reverse()
+            .join(",")}</gml:coordinates>
+        </gml:Point>
+      </ogc:Contains>
+    </ogc:Filter>
+  `;
+  // Define (WFS) parameters object
+  const wfsParams = {
+    key: import.meta.env.VITE_APP_OS_WFS_KEY,
+    service: "WFS",
+    request: "GetFeature",
+    version: "2.0.0",
+    typeNames: "Topography_TopographicArea",
+    propertyName: "TOID,DescriptiveGroup,SHAPE",
+    outputFormat: "GEOJSON",
+    srsName: "urn:ogc:def:crs:EPSG::4326",
+    filter: xml,
+    count: 1,
+  };
+
+  // Use fetch() method to request GeoJSON data from the OS Features API
+  // If successful, replace everything in the vector layer with the GeoJSON response
+  fetch(getUrl(wfsParams))
+    .then((response) => response.json())
+    .then((data) => {
+      console.log("features:", data);
+
+      if (!data.features.length) return;
+
+      const properties = data.features[0].properties,
+        validKeys = ["TOID", "DescriptiveGroup"];
+
+      Object.keys(properties).forEach(
+        (key) => validKeys.includes(key) || delete properties[key]
+      );
+
+      const geojson = new GeoJSON();
+
+      const features = geojson.readFeatures(data, {
+        featureProjection: "EPSG:3857",
+      });
+
+      featureSource.clear();
+      featureSource.addFeatures(features);
+    })
+    .catch((error) => console.log(error));
+}
+
+/**
+ * Helper function to return OS Features URL with encoded parameters
+ * @param {object} params - parameters object to be encoded
+ * @returns {string}
+ */
+function getUrl(params: any) {
+  const encodedParameters = Object.keys(params)
+    .map((paramName) => paramName + "=" + encodeURI(params[paramName]))
+    .join("&");
+
+  return `${featureServiceUrl}?${encodedParameters}`;
+}


### PR DESCRIPTION
creeping into the "future" features with this one, but the logic was basically already on hand from our first implementation! this will let us show a border around the address point in FindProperty component & move towards having a more accurate polygon/geojson to make more accurate planning constraint queries in the future.

example implementation:
```html
<my-map latitude="51.4858363" longitude="-0.0761246" showFeaturesAtPoint featureColor="#8a2be2" />
```