### PR TITLE
feat: npm publish main if package version changes

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,19 +1,35 @@
 name: Publish to NPM
 on:
-  push:
+  # to REMOVE before merge to main
+
+  pull_request:
+    types: [opened, synchronize]
     branches:
       - main
+
+  # to ADD before merge to main
+
+  # push:
+  #   branches:
+  #     - main
+
+env:
+  PNPM_VERSION: 6.31.0
+  NODE_VERSION: 16.14.2 # LTS
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
-      - run: npm install -g pnpm
-      - run: pnpm install
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+          cache-dependency-path: "**/pnpm-lock.yaml"
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,20 @@
+name: Publish to NPM
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - run: npm install -g pnpm
+      - run: pnpm install
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          dry-run: true


### PR DESCRIPTION
Currently set to dry-run for testing. I'm not sure if it'll like pnpm yet. GitHub is being weird too so I'll try this out tomorrow.

In theory we can keep merging to main as we are, then when we want to create a release, we create a PR that bumps the package version number (and any CHANGELOG updates) and it'll then auto publish on merge.