### PR TITLE
fix: 'reset' erases drawing when geojson data is also displayed

### DIFF
--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -138,7 +138,7 @@ export class MyMap extends LitElement {
       if (this.showFeaturesAtPoint) {
         const extent = featureSource.getExtent();
         map.getView().fit(buffer(extent, this.featureBuffer));
-      } else if (this.geojsonData.features.length > 0) {
+      } else if (outlineSource.getFeatures().length > 0) {
         const extent = outlineSource.getExtent();
         map.getView().fit(buffer(extent, this.geojsonBuffer));
       } else {


### PR DESCRIPTION
Fixes #38 

Was introduced when I adjusted geojsonData to accept type "Feature" _or_ "FeatureCollection", so was only erasing "FeatureCollection" geojson formats and still ignoring newly supported type "Feature" - works for both now!