### PR TITLE
feat: `clickFeatures` mode 

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prepublishOnly": "rm -rf dist types && npm run build"
   },
   "dependencies": {
+    "@turf/union": "^6.5.0",
     "lit": "^2.0.0-rc.2",
     "ol": "^6.6.1",
     "ol-mapbox-style": "^6.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 lockfileVersion: 5.3
 
 specifiers:
+  '@turf/union': ^6.5.0
   '@types/node': ^16.4.13
   husky: ^7.0.1
   lint-staged: ^11.1.2
@@ -13,6 +14,7 @@ specifiers:
   vite: ^2.4.4
 
 dependencies:
+  '@turf/union': 6.5.0
   lit: 2.0.0-rc.2
   ol: 6.6.1
   ol-mapbox-style: 6.4.1_ol@6.6.1
@@ -78,6 +80,24 @@ packages:
 
   /@mapbox/unitbezier/0.0.0:
     resolution: {integrity: sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4=}
+    dev: false
+
+  /@turf/helpers/6.5.0:
+    resolution: {integrity: sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==}
+    dev: false
+
+  /@turf/invariant/6.5.0:
+    resolution: {integrity: sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==}
+    dependencies:
+      '@turf/helpers': 6.5.0
+    dev: false
+
+  /@turf/union/6.5.0:
+    resolution: {integrity: sha512-igYWCwP/f0RFHIlC2c0SKDuM/ObBaqSljI3IdV/x71805QbIvY/BYGcJdyNcgEA6cylIGl/0VSlIbpJHZ9ldhw==}
+    dependencies:
+      '@turf/helpers': 6.5.0
+      '@turf/invariant': 6.5.0
+      polygon-clipping: 0.15.3
     dev: false
 
   /@types/node/16.4.13:
@@ -633,6 +653,12 @@ packages:
       semver-compare: 1.0.0
     dev: true
 
+  /polygon-clipping/0.15.3:
+    resolution: {integrity: sha512-ho0Xx5DLkgxRx/+n4O74XyJ67DcyN3Tu9bGYKsnTukGAW6ssnuak6Mwcyb1wHy9MZc9xsUWqIoiazkZB5weECg==}
+    dependencies:
+      splaytree: 3.1.0
+    dev: false
+
   /postcss/8.3.6:
     resolution: {integrity: sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==}
     engines: {node: ^10 || ^12 || >=14}
@@ -771,6 +797,10 @@ packages:
     resolution: {integrity: sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /splaytree/3.1.0:
+    resolution: {integrity: sha512-gvUGR7xnOy0fLKTCxDeUZYgU/I1Tdf8M/lM1Qrf8L2TIOR5ipZjGk02uYcdv0o2x7WjVRgpm3iS2clLyuVAt0Q==}
+    dev: false
 
   /string-argv/0.3.1:
     resolution: {integrity: sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==}


### PR DESCRIPTION
feels like this is popping up as a natural next step if we're going to start showing the single feature that intersects with an address point in FindProperty - if we only highlight the building footprint, it's natural to want to click/merge the yard feature etc.

done:
- outlineSource/outlineLayer renamed to geojsonSource/geojsonLayer; outline naming now used to reference merged features
- query features on single click and merge into outlineSource, calculate combined area

todo:
- what should happen on "reset"?
- should you only be allowed to go into `clickFeatures1 mode if `showFeaturesAtPoint` is also enabled? Or a case to start clicking from scratch?
- should this be allowed to co-exist with `drawMode`? what about `geojsonData`?
- update README
