### PR TITLE
feat: show vertices of drawn polygon

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     />
   </head>
   <body>
-    <my-map zoom="18" drawMode />
+    <my-map zoom="18" maxZoom="20" drawMode />
 
     <script>
       const map = document.querySelector("my-map");

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -4,9 +4,20 @@ import { Vector as VectorLayer } from "ol/layer";
 import { Vector as VectorSource } from "ol/source";
 import { Circle as CircleStyle, Fill, RegularShape, Stroke, Style } from "ol/style";
 
-const redLineStroke = new Stroke({
-  color: "#ff0000",
+const redLineBase = {
+  color: '#ff0000',
   width: 3,
+};
+
+const redLineStroke = new Stroke(redLineBase);
+
+const redDashedStroke = new Stroke({
+  ...redLineBase,
+  lineDash: [2, 8],
+});
+
+const redLineFill = new Fill({
+  color: "rgba(255, 0, 0, 0.1)",
 });
 
 const drawingPointer = new CircleStyle({
@@ -25,7 +36,7 @@ const drawingVertices = new Style({
       color: "#ff0000",
       width: 2,
     }),
-    points: 4,
+    points: 4, // squares
     radius: 5,
     angle: Math.PI / 4,
   }),
@@ -42,9 +53,7 @@ export const drawingLayer = new VectorLayer({
   source: drawingSource,
   style: [
     new Style({
-      fill: new Fill({
-        color: "rgba(255, 0, 0, 0.1)",
-      }),
+      fill: redLineFill,
       stroke: redLineStroke,
     }),
     drawingVertices,
@@ -55,14 +64,8 @@ export const draw = new Draw({
   source: drawingSource,
   type: "Polygon",
   style: new Style({
-    stroke: new Stroke({
-      color: "#ff0000",
-      width: 3,
-      lineDash: [2, 8],
-    }),
-    fill: new Fill({
-      color: "rgba(255, 255, 255, 0.2)",
-    }),
+    stroke: redDashedStroke,
+    fill: redLineFill,
     image: drawingPointer,
   }),
 });

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -1,7 +1,8 @@
+import MultiPoint from 'ol/geom/MultiPoint';
 import { Draw, Modify, Snap } from "ol/interaction";
 import { Vector as VectorLayer } from "ol/layer";
 import { Vector as VectorSource } from "ol/source";
-import { Circle as CircleStyle, Fill, Stroke, Style } from "ol/style";
+import { Circle as CircleStyle, Fill, RegularShape, Stroke, Style } from "ol/style";
 
 const redLineStroke = new Stroke({
   color: "#ff0000",
@@ -15,16 +16,39 @@ const drawingPointer = new CircleStyle({
   }),
 });
 
+const drawingVertices = new Style({
+  image: new RegularShape({
+    fill: new Fill({
+      color: "#fff"
+    }),
+    stroke: new Stroke({
+      color: "#ff0000",
+      width: 2,
+    }),
+    points: 4,
+    radius: 5,
+    angle: Math.PI / 4,
+  }),
+  geometry: function (feature) {
+    // return the coordinates of the drawn polygon
+    const coordinates = feature.getGeometry().getCoordinates()[0];
+    return new MultiPoint(coordinates);
+  },
+});
+
 export const drawingSource = new VectorSource();
 
 export const drawingLayer = new VectorLayer({
   source: drawingSource,
-  style: new Style({
-    fill: new Fill({
-      color: "rgba(255, 255, 255, 0.4)",
+  style: [
+    new Style({
+      fill: new Fill({
+        color: "rgba(255, 0, 0, 0.1)",
+      }),
+      stroke: redLineStroke,
     }),
-    stroke: redLineStroke,
-  }),
+    drawingVertices,
+  ]
 });
 
 export const draw = new Draw({
@@ -45,7 +69,7 @@ export const draw = new Draw({
 
 export const snap = new Snap({
   source: drawingSource,
-  pixelTolerance: 5,
+  pixelTolerance: 15,
 });
 
 export const modify = new Modify({


### PR DESCRIPTION
- Show vertices of drawn polygon once a shape has been closed; user can modify existing vertices or add new ones (design similar to MapInfo Professional used internally at Buckinghamshire)
- Tweak default drawing style to have more prominent fill color
- Increase snap pixel tolerance against drawing layer so it's a bit easier to close your drawing & grab an existing vertex to modify

![Screenshot from 2021-09-12 13-54-08](https://user-images.githubusercontent.com/5132349/132986727-5a14d3a0-bb18-47ca-bfd0-2a1c13430532.png)
