### PR TITLE
feat: dispatch events for area and geojson changes beyond drawMode

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,11 +22,26 @@
       map.addEventListener("ready", (event) => {
         console.log("map ready");
       });
+
+      // applicable when drawMode is enabled
       map.addEventListener("areaChange", ({ detail: area }) => {
         console.debug({ area });
       });
       map.addEventListener("geojsonChange", ({ detail: geojson }) => {
         console.debug({ geojson });
+      });
+
+      // applicable when showFeaturesAtPoint is enabled
+      map.addEventListener("featuresAreaChange", ({ detail: featuresArea }) => {
+        console.debug({ featuresArea });
+      });
+      map.addEventListener("featuresGeojsonChange", ({ detail: featuresGeojson }) => {
+        console.debug({ featuresGeojson });
+      });
+
+      // applicable when geojsonData is provided
+      map.addEventListener("geojsonDataArea", ({ detail: geojsonDataArea }) => {
+        console.debug({ geojsonDataArea });
       });
     </script>
   </body>

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -248,9 +248,12 @@ export class MyMap extends LitElement {
       // fit map to extent of geojson features, overriding default zoom & center
       fitToData(map, geojsonSource, this.geojsonBuffer);
 
-      // log total area of first feature (assumes geojson is a single polygon for now)
+      // log total area of static geojson data (assumes single polygon for now)
       const data = geojsonSource.getFeatures()[0].getGeometry();
-      console.log("geojsonData total area:", formatArea(data, this.areaUnit));
+      this.dispatch(
+        "geojsonDataArea",
+        formatArea(data, this.areaUnit)
+      );
     }
 
     if (this.drawMode) {
@@ -314,11 +317,19 @@ export class MyMap extends LitElement {
         ) {
           // fit map to extent of features
           fitToData(map, outlineSource, this.featureBuffer);
+          
+          // write the geojson representation of the feature or merged features
+          this.dispatch(
+            "featuresGeojsonChange",
+            new GeoJSON().writeFeaturesObject(outlineSource.getFeatures(), {
+              featureProjection: "EPSG:3857",
+            })
+          );
 
-          // log total area of feature or merged features
+          // calculate the total area of the feature or merged features
           const data = outlineSource.getFeatures()[0].getGeometry();
-          console.log(
-            "feature(s) total area:",
+          this.dispatch(
+            "featuresAreaChange",
             formatArea(data, this.areaUnit)
           );
         }


### PR DESCRIPTION
Replaces console.logs with `this.dispatch()` (which you'll still see in your console when debugging is enabled).

See index.html comments for which event names are applicable to which data "modes" (drawing, showing/clicking features, loading static data etc). 

This helps us prototype a click-to-select interaction in PlanX's DrawBoundary and have feature parity with current drawMode - for example, by showing the area below the map and setting `property.boundary.site` passport variables as the geojson representation of merged OS Features.

Closes #23 