### PR TITLE
feat: ability to read geojson polygon into initial drawing layer

### DIFF
--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -72,6 +72,15 @@ export class MyMap extends LitElement {
   @property({ type: Boolean })
   drawMode = false;
 
+  @property({ type: Object })
+  drawGeojsonData = {
+    type: "Feature",
+    geometry: {},
+  };
+
+  @property({ type: Number })
+  drawGeojsonDataBuffer = 100;
+
   @property({ type: Boolean })
   showFeaturesAtPoint = false;
 
@@ -254,11 +263,24 @@ export class MyMap extends LitElement {
     }
 
     if (this.drawMode) {
-      // ensure we start from an empty array of features
-      drawingSource.clear();
+      // check if single polygon feature was provided to load as the initial drawing
+      const loadInitialDrawing = Object.keys(this.drawGeojsonData.geometry).length > 0;
+      if (loadInitialDrawing) {
+        let feature = new GeoJSON().readFeature(this.drawGeojsonData, {
+          featureProjection: "EPSG:3857",
+        });
+        drawingSource.addFeature(feature);
+        // fit map to extent of intial feature, overriding zoom & lat/lng center
+        fitToData(map, drawingSource, this.drawGeojsonDataBuffer);
+      } else {
+        drawingSource.clear();
+      }
+
       map.addLayer(drawingLayer);
 
-      map.addInteraction(draw);
+      if (!loadInitialDrawing) {
+        map.addInteraction(draw);
+      }
       map.addInteraction(snap);
       map.addInteraction(modify);
 


### PR DESCRIPTION
This will enable us to "go back" to the DrawBoundary component in PlanX and load the site boundary that was originally drawn. The initial shape will load with the modification & snap interactions enabled so that you can alter it. The "reset" control will clear the layer and display the draw cursor anew, same as it works now. The drawing layer is still limited to one feature at a time.

Introducing two new optional properties (both assume `drawMode` is true/enabled): 
- `drawGeojsonData`: an object that accepts a single GeoJSON Feature with projection "EPSG:3857"
- `drawGeojsonDataBuffer`: a number to control the extent of the map view, defaults to 100

Example implementation:
```html
<body>
  <my-map zoom="18" maxZoom="20" drawMode />
  <script>
    const map = document.querySelector("my-map");
    map.drawGeojsonData = {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "type": "Polygon",
        "coordinates": [
          [
            [
              -0.12830883264541626,
              51.507844315947985
            ],
            [
              -0.12819081544876096,
              51.50762728992553
            ],
            [
              -0.12769192457199097,
              51.507712431026796
            ],
            [
              -0.12785017490386963,
              51.50795616741744
            ],
            [
              -0.12830883264541626,
              51.507844315947985
            ]
          ]
        ]
      }
    };

    map.addEventListener("ready", (event) => {
      console.log("map ready");
    });
    map.addEventListener("areaChange", ({ detail: area }) => {
      console.debug({ area });
    });
    map.addEventListener("geojsonChange", ({ detail: geojson }) => {
      console.debug({ geojson });
    });
  </script>
</body>
```

