### PR TITLE
tidy up snaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The minor version will be incremented upon a breaking change and the patch version will be
 incremented for features.
 
+## [0.3.3] - 2021-10-01
+
+### Added
+- feat: boolean property `geojsonFill` to style the fill color of a static geojson polygon as the specified stroke color with 20% opacity, disabled/false by default ([#64](https://github.com/theopensystemslab/map/pull/64))
+
 ## [0.3.2] - 2021-09-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The minor version will be incremented upon a breaking change and the patch version will be
 incremented for features.
 
+## [0.3.4] - 2021-10-01
+
+### Added
+- feat: boolean property `featureFill` to style the fill color of OS Features polygon as the specified stroke color with 20% opacity, disabled/false by default. Same idea as below, my oversight for not combining them into the same release! ([#66](https://github.com/theopensystemslab/map/pull/66))
+
 ## [0.3.3] - 2021-10-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The minor version will be incremented upon a breaking change and the patch version will be
 incremented for features.
 
+## [0.3.5] - 2021-10-27
+
+### Added
+- feat: ability to display a geojson polygon in the initial drawing layer when in `drawMode`, using new object property `drawGeojsonData` and number property `drawGeojsonBuffer` ([#70](https://github.com/theopensystemslab/map/pull/70))
+- feat: dispatch events `featuresAreaChange`, `featuresGeojsonChange` and `geojsonDataArea`, so that show/click features mode and loading static data has parity with existing event dispatching used in draw mode ([#69](https://github.com/theopensystemslab/map/pull/69))
+
 ## [0.3.4] - 2021-10-01
 
 ### Added

--- a/index.html
+++ b/index.html
@@ -22,11 +22,26 @@
       map.addEventListener("ready", (event) => {
         console.log("map ready");
       });
+
+      // applicable when drawMode is enabled
       map.addEventListener("areaChange", ({ detail: area }) => {
         console.debug({ area });
       });
       map.addEventListener("geojsonChange", ({ detail: geojson }) => {
         console.debug({ geojson });
+      });
+
+      // applicable when showFeaturesAtPoint is enabled
+      map.addEventListener("featuresAreaChange", ({ detail: featuresArea }) => {
+        console.debug({ featuresArea });
+      });
+      map.addEventListener("featuresGeojsonChange", ({ detail: featuresGeojson }) => {
+        console.debug({ featuresGeojson });
+      });
+
+      // applicable when geojsonData is provided
+      map.addEventListener("geojsonDataArea", ({ detail: geojsonDataArea }) => {
+        console.debug({ geojsonDataArea });
       });
     </script>
   </body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensystemslab/map",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "OGL-UK-3.0",
   "private": false,
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensystemslab/map",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "license": "OGL-UK-3.0",
   "private": false,
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensystemslab/map",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "license": "OGL-UK-3.0",
   "private": false,
   "repository": {

--- a/src/drawing.ts
+++ b/src/drawing.ts
@@ -78,9 +78,8 @@ export const draw = new Draw({
 });
 
 export const snap = new Snap({
-  // source: drawingSource,
   source: pointsSource,
-  pixelTolerance: 10,
+  pixelTolerance: 15,
 });
 
 export const modify = new Modify({

--- a/src/drawing.ts
+++ b/src/drawing.ts
@@ -78,7 +78,7 @@ export const draw = new Draw({
 });
 
 export const snap = new Snap({
-  source: pointsSource,
+  source: pointsSource, // empty if OS VectorTile basemap is disabled & zoom > 20
   pixelTolerance: 15,
 });
 

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -319,8 +319,12 @@ export class MyMap extends LitElement {
       });
     }
 
-    // show snapping points when in drawMode, with vector tiles enabled, and at zoom > 20
-    if (this.drawMode && !this.disableVectorTiles) {
+    // show snapping points when in drawMode, with vector tile basemap enabled, and at zoom > 20
+    if (
+      this.drawMode &&
+      Boolean(this.osVectorTilesApiKey) &&
+      !this.disableVectorTiles
+    ) {
       map.addLayer(pointsLayer);
 
       map.on("moveend", () => {

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -257,9 +257,12 @@ export class MyMap extends LitElement {
       // fit map to extent of geojson features, overriding default zoom & center
       fitToData(map, geojsonSource, this.geojsonBuffer);
 
-      // log total area of first feature (assumes geojson is a single polygon for now)
+      // log total area of static geojson data (assumes single polygon for now)
       const data = geojsonSource.getFeatures()[0].getGeometry();
-      console.log("geojsonData total area:", formatArea(data, this.areaUnit));
+      this.dispatch(
+        "geojsonDataArea",
+        formatArea(data, this.areaUnit)
+      );
     }
 
     if (this.drawMode) {
@@ -336,11 +339,19 @@ export class MyMap extends LitElement {
         ) {
           // fit map to extent of features
           fitToData(map, outlineSource, this.featureBuffer);
+          
+          // write the geojson representation of the feature or merged features
+          this.dispatch(
+            "featuresGeojsonChange",
+            new GeoJSON().writeFeaturesObject(outlineSource.getFeatures(), {
+              featureProjection: "EPSG:3857",
+            })
+          );
 
-          // log total area of feature or merged features
+          // calculate the total area of the feature or merged features
           const data = outlineSource.getFeatures()[0].getGeometry();
-          console.log(
-            "feature(s) total area:",
+          this.dispatch(
+            "featuresAreaChange",
             formatArea(data, this.areaUnit)
           );
         }

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -81,6 +81,9 @@ export class MyMap extends LitElement {
   @property({ type: String })
   featureColor = "#0000ff";
 
+  @property({ type: Boolean })
+  featureFill = false;
+
   @property({ type: Number })
   featureBuffer = 40;
 
@@ -297,7 +300,10 @@ export class MyMap extends LitElement {
         });
       }
 
-      const outlineLayer = makeFeatureLayer(this.featureColor);
+      const outlineLayer = makeFeatureLayer(
+        this.featureColor,
+        this.featureFill
+      );
       map.addLayer(outlineLayer);
 
       // ensure getFeaturesAtPoint has fetched successfully

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -72,6 +72,15 @@ export class MyMap extends LitElement {
   @property({ type: Boolean })
   drawMode = false;
 
+  @property({ type: Object })
+  drawGeojsonData = {
+    type: "Feature",
+    geometry: {},
+  };
+
+  @property({ type: Number })
+  drawGeojsonDataBuffer = 100;
+
   @property({ type: Boolean })
   showFeaturesAtPoint = false;
 
@@ -254,11 +263,24 @@ export class MyMap extends LitElement {
     }
 
     if (this.drawMode) {
-      // ensure we start from an empty array of features
-      drawingSource.clear();
+      // check if single polygon feature was provided to load as the initial drawing
+      const loadInitialDrawing = Object.keys(this.drawGeojsonData.geometry).length > 0;
+      if (loadInitialDrawing) {
+        let feature = new GeoJSON().readFeature(this.drawGeojsonData, {
+          featureProjection: "EPSG:3857",
+        });
+        drawingSource.addFeature(feature);
+        // fit map to extent of intial feature, overriding zoom & lat/lng center
+        fitToData(map, drawingSource, this.drawGeojsonDataBuffer);
+      } else {
+        drawingSource.clear();
+      }
+
       map.addLayer(drawingLayer);
 
-      map.addInteraction(draw);
+      if (!loadInitialDrawing) {
+        map.addInteraction(draw);
+      }
       map.addInteraction(snap);
       map.addInteraction(modify);
 

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -7,19 +7,19 @@ import { Vector as VectorLayer } from "ol/layer";
 import Map from "ol/Map";
 import { fromLonLat, transformExtent } from "ol/proj";
 import { Vector as VectorSource } from "ol/source";
-import { Stroke, Style } from "ol/style";
+import { Fill, Stroke, Style } from "ol/style";
 import View from "ol/View";
 import { last } from "rambda";
 
 import { draw, drawingLayer, drawingSource, modify, snap } from "./draw";
-import { scaleControl } from "./scale-line"
+import { scaleControl } from "./scale-line";
 import {
   makeFeatureLayer,
   outlineSource,
   getFeaturesAtPoint,
 } from "./os-features";
 import { makeOsVectorTileBaseMap, makeRasterBaseMap } from "./os-layers";
-import { AreaUnitEnum, fitToData, formatArea } from "./utils";
+import { AreaUnitEnum, fitToData, formatArea, hexToRgba } from "./utils";
 
 @customElement("my-map")
 export class MyMap extends LitElement {
@@ -93,6 +93,9 @@ export class MyMap extends LitElement {
   @property({ type: String })
   geojsonColor = "#ff0000";
 
+  @property({ type: Boolean })
+  geojsonFill = false;
+
   @property({ type: Number })
   geojsonBuffer = 12;
 
@@ -112,11 +115,11 @@ export class MyMap extends LitElement {
   staticMode = false;
 
   @property({ type: String })
-  areaUnit: AreaUnitEnum = "m2"
+  areaUnit: AreaUnitEnum = "m2";
 
   @property({ type: String })
   ariaLabel = "Interactive map";
-  
+
   @property({ type: Boolean })
   showScale = false;
 
@@ -228,6 +231,11 @@ export class MyMap extends LitElement {
           color: this.geojsonColor,
           width: 3,
         }),
+        fill: new Fill({
+          color: this.geojsonFill
+            ? hexToRgba(this.geojsonColor, 0.2)
+            : hexToRgba(this.geojsonColor, 0),
+        }),
       }),
     });
 
@@ -265,7 +273,10 @@ export class MyMap extends LitElement {
             })
           );
 
-          this.dispatch("areaChange", formatArea(lastSketchGeom, this.areaUnit));
+          this.dispatch(
+            "areaChange",
+            formatArea(lastSketchGeom, this.areaUnit)
+          );
 
           // limit to drawing a single polygon, only allow modifications to existing shape
           map.removeInteraction(draw);
@@ -300,7 +311,10 @@ export class MyMap extends LitElement {
 
           // log total area of feature or merged features
           const data = outlineSource.getFeatures()[0].getGeometry();
-          console.log("feature(s) total area:", formatArea(data, this.areaUnit));
+          console.log(
+            "feature(s) total area:",
+            formatArea(data, this.areaUnit)
+          );
         }
       });
     }
@@ -317,10 +331,7 @@ export class MyMap extends LitElement {
   render() {
     return html`<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
       <link rel="stylesheet" href="https://cdn.skypack.dev/ol@^6.6.1/ol.css" />
-      <div 
-        id="map" 
-        tabindex="0"
-        aria-label=${this.ariaLabel} />`;
+      <div id="map" tabindex="0" aria-label=${this.ariaLabel} />`;
   }
 
   /**

--- a/src/os-features.ts
+++ b/src/os-features.ts
@@ -3,7 +3,9 @@ import { GeoJSON } from "ol/format";
 import { Vector as VectorLayer } from "ol/layer";
 import { toLonLat } from "ol/proj";
 import { Vector as VectorSource } from "ol/source";
-import { Stroke, Style } from "ol/style";
+import { Fill, Stroke, Style } from "ol/style";
+
+import { hexToRgba } from "./utils";
 
 const featureServiceUrl = "https://api.os.uk/features/v1/wfs";
 
@@ -11,13 +13,16 @@ const featureSource = new VectorSource();
 
 export const outlineSource = new VectorSource();
 
-export function makeFeatureLayer(color: string) {
+export function makeFeatureLayer(color: string, featureFill: boolean) {
   return new VectorLayer({
     source: outlineSource,
     style: new Style({
       stroke: new Stroke({
         width: 3,
         color: color,
+      }),
+      fill: new Fill({
+        color: featureFill ? hexToRgba(color, 0.2) : hexToRgba(color, 0),
       }),
     }),
   });

--- a/src/snapping.ts
+++ b/src/snapping.ts
@@ -1,8 +1,11 @@
+import { Feature } from "ol";
+import Point from "ol/geom/Point";
 import { Vector as VectorLayer } from "ol/layer";
 import VectorTileLayer from "ol/layer/VectorTile";
 import VectorSource from "ol/source/Vector";
 import { Fill, Style } from "ol/style";
 import CircleStyle from "ol/style/Circle";
+import { splitEvery } from "rambda";
 
 export const pointsSource = new VectorSource({
   features: [],
@@ -11,29 +14,38 @@ export const pointsSource = new VectorSource({
 
 export const pointsLayer = new VectorLayer({
   source: pointsSource,
-  style: function () {
-    return new Style({
-      image: new CircleStyle({
-        radius: 4,
-        fill: new Fill({ color: "green" }),
+  style: new Style({
+    image: new CircleStyle({
+      radius: 3,
+      fill: new Fill({
+        color: "black",
       }),
-    });
-  },
+    }),
+  }),
 });
 
 /**
  * Extract points that are available to snap to when a VectorTileLayer basemap is displayed
  * @param basemap - a VectorTileLayer
  * @param extent - an array of 4 points
- * @returns - an array of points within the extent
+ * @returns - a VectorSource populated with points within the extent
  */
-export function getPointsFromVectorTiles(
+export function getSnapPointsFromVectorTiles(
   basemap: VectorTileLayer,
   extent: number[]
 ) {
-  return basemap
+  const points = basemap
     .getSource()
     .getFeaturesInExtent(extent)
     .filter((feature) => feature.getGeometry().getType() !== "Point")
     .flatMap((feature: any) => feature.flatCoordinates_);
+
+  return (splitEvery(2, points) as [number, number][]).forEach((pair, i) => {
+    pointsSource.addFeature(
+      new Feature({
+        geometry: new Point(pair),
+        i,
+      })
+    );
+  });
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,11 @@
+import { asArray, asString } from "ol/color";
 import { buffer } from "ol/extent";
 import Geometry from "ol/geom/Geometry";
 import Map from "ol/Map";
 import { Vector } from "ol/source";
 import { getArea } from "ol/sphere";
 
-export type AreaUnitEnum =  "m2" | "ha";
+export type AreaUnitEnum = "m2" | "ha";
 
 /**
  * Calculate & format the area of a polygon
@@ -42,4 +43,15 @@ export function fitToData(
 ) {
   const extent = olSource.getExtent();
   return olMap.getView().fit(buffer(extent, bufferValue));
+}
+
+/**
+ * Translate a hex color to an rgba string with opacity
+ * @param hexColor - a hex color string
+ * @param alpha - a decimal to represent opacity
+ * @returns - a 'rgba(r,g,b,a)' string
+ */
+export function hexToRgba(hexColor: string, alpha: number) {
+  const [r, g, b] = Array.from(asArray(hexColor));
+  return asString([r, g, b, alpha]);
 }


### PR DESCRIPTION
looks like more than it is because i'm based off main!

makes sure we only add the snapping layer when in drawMode with the vectorTile basemap enabled

shuffles the code around a bit to keep it closer to drawing logic in the flow of my-map.ts, and moves a couple more definitions to snapping.ts

not thinking about styling yet! maybe just easiest to set a snapping color property so it's easy to keep changing minds about? :upside_down_face: 

also still thinking about how snaps should work once you close your shape? can we actually modify-to-snaps? if we cant, maybe points should disappear?