### PR TITLE
feat: snap to vector tile basemap features

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     />
   </head>
   <body>
-    <my-map zoom="18" maxZoom="20" drawMode />
+    <my-map zoom="18" maxZoom="23" drawMode />
 
     <script>
       const map = document.querySelector("my-map");

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -1,11 +1,18 @@
-import MultiPoint from 'ol/geom/MultiPoint';
+import MultiPoint from "ol/geom/MultiPoint";
 import { Draw, Modify, Snap } from "ol/interaction";
 import { Vector as VectorLayer } from "ol/layer";
 import { Vector as VectorSource } from "ol/source";
-import { Circle as CircleStyle, Fill, RegularShape, Stroke, Style } from "ol/style";
+import {
+  Circle as CircleStyle,
+  Fill,
+  RegularShape,
+  Stroke,
+  Style,
+} from "ol/style";
+import { pointsSource } from "./snapping";
 
 const redLineBase = {
-  color: '#ff0000',
+  color: "#ff0000",
   width: 3,
 };
 
@@ -30,7 +37,7 @@ const drawingPointer = new CircleStyle({
 const drawingVertices = new Style({
   image: new RegularShape({
     fill: new Fill({
-      color: "#fff"
+      color: "#fff",
     }),
     stroke: new Stroke({
       color: "#ff0000",
@@ -57,7 +64,7 @@ export const drawingLayer = new VectorLayer({
       stroke: redLineStroke,
     }),
     drawingVertices,
-  ]
+  ],
 });
 
 export const draw = new Draw({
@@ -71,8 +78,9 @@ export const draw = new Draw({
 });
 
 export const snap = new Snap({
-  source: drawingSource,
-  pixelTolerance: 15,
+  // source: drawingSource,
+  source: pointsSource,
+  pixelTolerance: 10,
 });
 
 export const modify = new Modify({

--- a/src/drawing.ts
+++ b/src/drawing.ts
@@ -78,9 +78,8 @@ export const draw = new Draw({
 });
 
 export const snap = new Snap({
-  // source: drawingSource,
   source: pointsSource,
-  pixelTolerance: 10,
+  pixelTolerance: 15,
 });
 
 export const modify = new Modify({

--- a/src/drawing.ts
+++ b/src/drawing.ts
@@ -78,7 +78,7 @@ export const draw = new Draw({
 });
 
 export const snap = new Snap({
-  source: pointsSource,
+  source: pointsSource, // empty if OS VectorTile basemap is disabled & zoom > 20
   pixelTolerance: 15,
 });
 

--- a/src/drawing.ts
+++ b/src/drawing.ts
@@ -27,11 +27,13 @@ const redLineFill = new Fill({
   color: "rgba(255, 0, 0, 0.1)",
 });
 
-const drawingPointer = new CircleStyle({
-  radius: 6,
+const drawingPointer = new RegularShape({
   fill: new Fill({
-    color: "#ff0000",
+    color: 'red'
   }),
+  points: 4, // crosshair aka star
+  radius1: 15, // outer radius
+  radius2: 3, // inner radius
 });
 
 const drawingVertices = new Style({

--- a/src/drawing.ts
+++ b/src/drawing.ts
@@ -27,12 +27,13 @@ const redLineFill = new Fill({
 });
 
 const drawingPointer = new RegularShape({
-  fill: new Fill({
-    color: 'red'
+  stroke: new Stroke({
+    color: 'red',
+    width: 2,
   }),
   points: 4, // crosshair aka star
   radius1: 15, // outer radius
-  radius2: 3, // inner radius
+  radius2: 1, // inner radius
 });
 
 const drawingVertices = new Style({

--- a/src/drawing.ts
+++ b/src/drawing.ts
@@ -3,7 +3,6 @@ import { Draw, Modify, Snap } from "ol/interaction";
 import { Vector as VectorLayer } from "ol/layer";
 import { Vector as VectorSource } from "ol/source";
 import {
-  Circle as CircleStyle,
   Fill,
   RegularShape,
   Stroke,

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -319,8 +319,12 @@ export class MyMap extends LitElement {
       });
     }
 
-    // show snapping points when in drawMode, with vector tiles enabled, and at zoom > 20
-    if (this.drawMode && !this.disableVectorTiles) {
+    // show snapping points when in drawMode, with vector tile basemap enabled, and at zoom > 20
+    if (
+      this.drawMode &&
+      Boolean(this.osVectorTilesApiKey) &&
+      !this.disableVectorTiles
+    ) {
       map.addLayer(pointsLayer);
 
       map.on("moveend", () => {

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -1,7 +1,9 @@
 import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import { Feature } from "ol";
 import { Control, defaults as defaultControls } from "ol/control";
 import { GeoJSON } from "ol/format";
+import Point from "ol/geom/Point";
 import { defaults as defaultInteractions } from "ol/interaction";
 import { Vector as VectorLayer } from "ol/layer";
 import Map from "ol/Map";
@@ -9,16 +11,21 @@ import { fromLonLat, transformExtent } from "ol/proj";
 import { Vector as VectorSource } from "ol/source";
 import { Fill, Stroke, Style } from "ol/style";
 import View from "ol/View";
-import { last } from "rambda";
+import { last, splitEvery } from "rambda";
 
 import { draw, drawingLayer, drawingSource, modify, snap } from "./draw";
-import { scaleControl } from "./scale-line";
 import {
+  getFeaturesAtPoint,
   makeFeatureLayer,
   outlineSource,
-  getFeaturesAtPoint,
 } from "./os-features";
 import { makeOsVectorTileBaseMap, makeRasterBaseMap } from "./os-layers";
+import { scaleControl } from "./scale-line";
+import {
+  getPointsFromVectorTiles,
+  pointsLayer,
+  pointsSource,
+} from "./snapping";
 import { AreaUnitEnum, fitToData, formatArea, hexToRgba } from "./utils";
 
 @customElement("my-map")
@@ -221,7 +228,7 @@ export class MyMap extends LitElement {
       map.getViewport().style.cursor = "grab";
     });
 
-    // add a vector layer to display static geojson if features are provided
+    // display static geojson if features are provided
     const geojsonSource = new VectorSource();
 
     if (this.geojsonData.type === "FeatureCollection") {
@@ -259,15 +266,14 @@ export class MyMap extends LitElement {
 
       // log total area of static geojson data (assumes single polygon for now)
       const data = geojsonSource.getFeatures()[0].getGeometry();
-      this.dispatch(
-        "geojsonDataArea",
-        formatArea(data, this.areaUnit)
-      );
+      this.dispatch("geojsonDataArea", formatArea(data, this.areaUnit));
     }
 
+    // draw interactions
     if (this.drawMode) {
       // check if single polygon feature was provided to load as the initial drawing
-      const loadInitialDrawing = Object.keys(this.drawGeojsonData.geometry).length > 0;
+      const loadInitialDrawing =
+        Object.keys(this.drawGeojsonData.geometry).length > 0;
       if (loadInitialDrawing) {
         let feature = new GeoJSON().readFeature(this.drawGeojsonData, {
           featureProjection: "EPSG:3857",
@@ -313,6 +319,35 @@ export class MyMap extends LitElement {
       });
     }
 
+    // show snapping points when in drawMode, with vector tiles enabled, and at zoom > 20
+    if (this.drawMode && !this.disableVectorTiles) {
+      map.addLayer(pointsLayer);
+
+      map.on("moveend", () => {
+        if (map.getView().getZoom() < 20) {
+          pointsSource.clear();
+          return;
+        }
+
+        setTimeout(() => {
+          pointsSource.clear();
+          const extent = map.getView().calculateExtent(map.getSize());
+
+          // extract points form the basemap, and display them as a layer of coordinate pairs on the map
+          const points = getPointsFromVectorTiles(osVectorTileBaseMap, extent);
+          (splitEvery(2, points) as [number, number][]).forEach((pair, i) => {
+            pointsSource.addFeature(
+              new Feature({
+                geometry: new Point(pair),
+                i,
+              })
+            );
+          });
+        }, 200);
+      });
+    }
+
+    // OS Features API & click-to-select interactions
     if (this.showFeaturesAtPoint && Boolean(this.osFeaturesApiKey)) {
       getFeaturesAtPoint(
         fromLonLat([this.longitude, this.latitude]),
@@ -339,7 +374,7 @@ export class MyMap extends LitElement {
         ) {
           // fit map to extent of features
           fitToData(map, outlineSource, this.featureBuffer);
-          
+
           // write the geojson representation of the feature or merged features
           this.dispatch(
             "featuresGeojsonChange",
@@ -350,10 +385,7 @@ export class MyMap extends LitElement {
 
           // calculate the total area of the feature or merged features
           const data = outlineSource.getFeatures()[0].getGeometry();
-          this.dispatch(
-            "featuresAreaChange",
-            formatArea(data, this.areaUnit)
-          );
+          this.dispatch("featuresAreaChange", formatArea(data, this.areaUnit));
         }
       });
     }

--- a/src/snapping.ts
+++ b/src/snapping.ts
@@ -1,0 +1,39 @@
+import { Vector as VectorLayer } from "ol/layer";
+import VectorTileLayer from "ol/layer/VectorTile";
+import VectorSource from "ol/source/Vector";
+import { Fill, Style } from "ol/style";
+import CircleStyle from "ol/style/Circle";
+
+export const pointsSource = new VectorSource({
+  features: [],
+  wrapX: false,
+});
+
+export const pointsLayer = new VectorLayer({
+  source: pointsSource,
+  style: function () {
+    return new Style({
+      image: new CircleStyle({
+        radius: 4,
+        fill: new Fill({ color: "green" }),
+      }),
+    });
+  },
+});
+
+/**
+ * Extract points that are available to snap to when a VectorTileLayer basemap is displayed
+ * @param basemap - a VectorTileLayer
+ * @param extent - an array of 4 points
+ * @returns - an array of points within the extent
+ */
+export function getPointsFromVectorTiles(
+  basemap: VectorTileLayer,
+  extent: number[]
+) {
+  return basemap
+    .getSource()
+    .getFeaturesInExtent(extent)
+    .filter((feature) => feature.getGeometry().getType() !== "Point")
+    .flatMap((feature: any) => feature.flatCoordinates_);
+}

--- a/src/snapping.ts
+++ b/src/snapping.ts
@@ -1,8 +1,11 @@
+import { Feature } from "ol";
+import Point from "ol/geom/Point";
 import { Vector as VectorLayer } from "ol/layer";
 import VectorTileLayer from "ol/layer/VectorTile";
 import VectorSource from "ol/source/Vector";
 import { Fill, Style } from "ol/style";
 import CircleStyle from "ol/style/Circle";
+import { splitEvery } from "rambda";
 
 export const pointsSource = new VectorSource({
   features: [],
@@ -11,29 +14,38 @@ export const pointsSource = new VectorSource({
 
 export const pointsLayer = new VectorLayer({
   source: pointsSource,
-  style: function () {
-    return new Style({
-      image: new CircleStyle({
-        radius: 4,
-        fill: new Fill({ color: "green" }),
+  style: new Style({
+    image: new CircleStyle({
+      radius: 3,
+      fill: new Fill({
+        color: "black",
       }),
-    });
-  },
+    }),
+  }),
 });
 
 /**
  * Extract points that are available to snap to when a VectorTileLayer basemap is displayed
  * @param basemap - a VectorTileLayer
  * @param extent - an array of 4 points
- * @returns - an array of points within the extent
+ * @returns - a VectorSource populated with points within the extent
  */
-export function getPointsFromVectorTiles(
+export function getSnapPointsFromVectorTiles(
   basemap: VectorTileLayer,
   extent: number[]
 ) {
-  return basemap
+  const points = basemap
     .getSource()
     .getFeaturesInExtent(extent)
     .filter((feature) => feature.getGeometry().getType() !== "Point")
     .flatMap((feature: any) => feature.flatCoordinates_);
+
+  return (splitEvery(2, points) as [number, number][]).forEach((pair, i) => {
+    pointsSource.addFeature(
+      new Feature({
+        geometry: new Point(pair),
+        i,
+      })
+    );
+  });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "emitDeclarationOnly": true,
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es2017", "dom", "dom.iterable"],
+    "lib": ["es2019", "dom", "dom.iterable"],
     "module": "es2020",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Implementation assumptions: 
- Snapping is only possible if OS Vector Tiles basemap is enabled (not OS Raster basemap or OSM); this requires OS API key
- Snapping points appear when `drawMode` is enabled and zoom level > 20
- Snapping points remain visible after you've closed your shape as reference points, but when modifying you won't get the same pixelTolerance/gravitational pull towards the snaps as you do when in initial drawing mode

Default styles:
- Drawing cursor is updated to red crosshair rather than dot
- Snapping points are solid black with a radius of 3 pixels, a bit smaller than drawing cursor and red drawing vertices
- Drawing vertices will always appear _on top of_ snapping points
- Color & size are currently not user configurable, but please say so if this is a MVP priority and we can convert to a Lit property!

![chrome-capture (3)](https://user-images.githubusercontent.com/5132349/141106178-1f9d46f0-513f-46a8-986b-6385cc797330.gif)

Closes #55 