### PR TITLE
feat: configurable drawing pointer style

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     />
   </head>
   <body>
-    <my-map zoom="18" maxZoom="23" drawMode />
+    <my-map zoom="18" maxZoom="23" drawMode drawPointer="dot" />
 
     <script>
       const map = document.querySelector("my-map");

--- a/src/drawing.ts
+++ b/src/drawing.ts
@@ -2,13 +2,11 @@ import MultiPoint from "ol/geom/MultiPoint";
 import { Draw, Modify, Snap } from "ol/interaction";
 import { Vector as VectorLayer } from "ol/layer";
 import { Vector as VectorSource } from "ol/source";
-import {
-  Fill,
-  RegularShape,
-  Stroke,
-  Style,
-} from "ol/style";
+import { Fill, RegularShape, Stroke, Style } from "ol/style";
+import CircleStyle from "ol/style/Circle";
 import { pointsSource } from "./snapping";
+
+export type DrawPointerEnum = "crosshair" | "dot";
 
 const redLineBase = {
   color: "#ff0000",
@@ -26,14 +24,21 @@ const redLineFill = new Fill({
   color: "rgba(255, 0, 0, 0.1)",
 });
 
-const drawingPointer = new RegularShape({
+const crosshair = new RegularShape({
   stroke: new Stroke({
-    color: 'red',
+    color: "red",
     width: 2,
   }),
   points: 4, // crosshair aka star
   radius1: 15, // outer radius
   radius2: 1, // inner radius
+});
+
+const dot = new CircleStyle({
+  radius: 6,
+  fill: new Fill({
+    color: "#ff0000",
+  }),
 });
 
 const drawingVertices = new Style({
@@ -69,24 +74,28 @@ export const drawingLayer = new VectorLayer({
   ],
 });
 
-export const draw = new Draw({
-  source: drawingSource,
-  type: "Polygon",
-  style: new Style({
-    stroke: redDashedStroke,
-    fill: redLineFill,
-    image: drawingPointer,
-  }),
-});
+export function configureDraw(pointerStyle: DrawPointerEnum) {
+  return new Draw({
+    source: drawingSource,
+    type: "Polygon",
+    style: new Style({
+      stroke: redDashedStroke,
+      fill: redLineFill,
+      image: pointerStyle === "crosshair" ? crosshair : dot,
+    }),
+  });
+}
 
 export const snap = new Snap({
   source: pointsSource, // empty if OS VectorTile basemap is disabled & zoom > 20
   pixelTolerance: 15,
 });
 
-export const modify = new Modify({
-  source: drawingSource,
-  style: new Style({
-    image: drawingPointer,
-  }),
-});
+export function configureModify(pointerStyle: DrawPointerEnum) {
+  return new Modify({
+    source: drawingSource,
+    style: new Style({
+      image: pointerStyle === "crosshair" ? crosshair : dot,
+    }),
+  });
+}

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -11,7 +11,14 @@ import { Fill, Stroke, Style } from "ol/style";
 import View from "ol/View";
 import { last } from "rambda";
 
-import { draw, drawingLayer, drawingSource, modify, snap } from "./drawing";
+import {
+  configureDraw,
+  configureModify,
+  drawingLayer,
+  drawingSource,
+  DrawPointerEnum,
+  snap,
+} from "./drawing";
 import {
   getFeaturesAtPoint,
   makeFeatureLayer,
@@ -43,11 +50,11 @@ export class MyMap extends LitElement {
       overflow: hidden;
     }
     #map:focus {
-      outline: #D3D3D3 solid 0.15em;
+      outline: #d3d3d3 solid 0.15em;
     }
     .ol-control button {
       border-radius: 0 !important;
-      background-color: #2C2C2C !important;
+      background-color: #2c2c2c !important;
     }
     .ol-control button:hover {
       background-color: rgba(44, 44, 44, 0.85) !important;
@@ -92,6 +99,9 @@ export class MyMap extends LitElement {
 
   @property({ type: Number })
   drawGeojsonDataBuffer = 100;
+
+  @property({ type: String })
+  drawPointer: DrawPointerEnum = "crosshair";
 
   @property({ type: Boolean })
   showFeaturesAtPoint = false;
@@ -189,6 +199,10 @@ export class MyMap extends LitElement {
         mouseWheelZoom: !this.staticMode,
       }),
     });
+
+    // make configurable interactions available
+    const draw = configureDraw(this.drawPointer);
+    const modify = configureModify(this.drawPointer);
 
     // add a custom 'reset' control below zoom
     const button = document.createElement("button");

--- a/src/snapping.ts
+++ b/src/snapping.ts
@@ -18,7 +18,7 @@ export const pointsLayer = new VectorLayer({
     image: new CircleStyle({
       radius: 3,
       fill: new Fill({
-        color: "black",
+        color: "grey",
       }),
     }),
   }),


### PR DESCRIPTION
- `drawPointer` property accepts "crosshair" (default, so this isn't a breaking change) or "dot"
- grey snap points instead of black
