### PR TITLE
fix: A11y improvements

### DIFF
--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -58,7 +58,7 @@ export class MyMap extends LitElement {
       cursor: pointer;
       min-width: 44px;
       min-height: 44px;
-      font-size: 1.5rem;
+      font-size: 1.75rem;
     }
     .ol-control button:hover {
       background-color: rgba(44, 44, 44, 0.85) !important;
@@ -248,7 +248,7 @@ export class MyMap extends LitElement {
 
     // Apply aria-labels to OL Controls for accessibility
     const olControls: NodeListOf<HTMLButtonElement> | undefined =
-      this.shadowRoot?.querySelectorAll(".ol-control button");
+      this.renderRoot?.querySelectorAll(".ol-control button");
     olControls?.forEach((node) =>
       node.setAttribute("aria-label", node.getAttribute("title") || "")
     );

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -55,12 +55,16 @@ export class MyMap extends LitElement {
     .ol-control button {
       border-radius: 0 !important;
       background-color: #2c2c2c !important;
+      cursor: pointer;
+      min-width: 44px;
+      min-height: 44px;
+      font-size: 1.5rem;
     }
     .ol-control button:hover {
       background-color: rgba(44, 44, 44, 0.85) !important;
     }
     .reset-control {
-      top: 70px;
+      top: 114px;
       left: 0.5em;
     }
     #area {
@@ -241,6 +245,13 @@ export class MyMap extends LitElement {
     if (!this.hideResetControl) {
       map.addControl(ResetControl);
     }
+
+    // Apply aria-labels to OL Controls for accessibility
+    const olControls: NodeListOf<HTMLButtonElement> | undefined =
+      this.shadowRoot?.querySelectorAll(".ol-control button");
+    olControls?.forEach((node) =>
+      node.setAttribute("aria-label", node.getAttribute("title") || "")
+    );
 
     // define cursors for dragging/panning and moving
     map.on("pointerdrag", () => {


### PR DESCRIPTION
Addresses issues raised in the following two tickets - 
 - https://trello.com/c/NqjvZifP/1666-non-descriptive-links-and-buttons
 - https://trello.com/c/luSUt9gd/1680-button-target-size

**Fixes**
- Ensure zoom and reset buttons are 44px x 44px
- Apply missing `pointer: cursor` to buttons
  - Presumably the way that the drag and move pointers are set are causing this issue
- Apply `aria-label` attribute to controls


![image](https://user-images.githubusercontent.com/20502206/145572738-e63af8aa-dca3-43ba-b2e2-e6f7a392646b.png)