### PR TITLE
fix: add prop to set unique id on element & clear the featureSource unless `clickFeatures` is enabled

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,16 +14,9 @@
     />
   </head>
   <body>
-    <div style="display: flex; flex-direction: column;">
-      <div style="margin: 1em">
-        <my-map showFeaturesAtPoint latitude="51.507351" longitude="-0.127758" id="map-1" />
-      </div>
-      <div style="margin: 1em">
-        <my-map showFeaturesAtPoint featureColor="#ff00ff" drawMode drawPointer="dot" latitude="51.506351" longitude="-0.124758" id="map-2" />
-      </div>
-    </div>
+    <my-map zoom="18" maxZoom="23" drawMode drawPointer="dot" id="example-map" />
 
-    <!-- <script>
+    <script>
       const map = document.querySelector("my-map");
 
       map.addEventListener("ready", (event) => {
@@ -50,6 +43,6 @@
       map.addEventListener("geojsonDataArea", ({ detail: geojsonDataArea }) => {
         console.debug({ geojsonDataArea });
       });
-    </script> -->
+    </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -14,9 +14,16 @@
     />
   </head>
   <body>
-    <my-map zoom="18" maxZoom="23" drawMode drawPointer="dot" />
+    <div style="display: flex; flex-direction: column;">
+      <div style="margin: 1em">
+        <my-map showFeaturesAtPoint latitude="51.507351" longitude="-0.127758" id="map-1" />
+      </div>
+      <div style="margin: 1em">
+        <my-map showFeaturesAtPoint latitude="51.506351" longitude="-0.124758" id="map-2" />
+      </div>
+    </div>
 
-    <script>
+    <!-- <script>
       const map = document.querySelector("my-map");
 
       map.addEventListener("ready", (event) => {
@@ -43,6 +50,6 @@
       map.addEventListener("geojsonDataArea", ({ detail: geojsonDataArea }) => {
         console.debug({ geojsonDataArea });
       });
-    </script>
+    </script> -->
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
         <my-map showFeaturesAtPoint latitude="51.507351" longitude="-0.127758" id="map-1" />
       </div>
       <div style="margin: 1em">
-        <my-map showFeaturesAtPoint latitude="51.506351" longitude="-0.124758" id="map-2" />
+        <my-map showFeaturesAtPoint featureColor="#ff00ff" drawMode drawPointer="dot" latitude="51.506351" longitude="-0.124758" id="map-2" />
       </div>
     </div>
 

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -329,18 +329,19 @@ export class MyMap extends LitElement {
 
     // draw interactions
     if (this.drawMode) {
-      // check if single polygon feature was provided to load as the initial drawing
+      // make sure drawingSource is cleared upfront, even if drawGeojsonData is provided
+      drawingSource.clear();
+
+      // load an initial polygon into the drawing source if provided, or start from an empty drawing source
       const loadInitialDrawing =
         Object.keys(this.drawGeojsonData.geometry).length > 0;
+
       if (loadInitialDrawing) {
         let feature = new GeoJSON().readFeature(this.drawGeojsonData, {
           featureProjection: "EPSG:3857",
         });
         drawingSource.addFeature(feature);
-        // fit map to extent of intial feature, overriding zoom & lat/lng center
         fitToData(map, drawingSource, this.drawGeojsonDataBuffer);
-      } else {
-        drawingSource.clear();
       }
 
       map.addLayer(drawingLayer);

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -409,7 +409,8 @@ export class MyMap extends LitElement {
     if (this.showFeaturesAtPoint && Boolean(this.osFeaturesApiKey)) {
       getFeaturesAtPoint(
         fromLonLat([this.longitude, this.latitude]),
-        this.osFeaturesApiKey
+        this.osFeaturesApiKey,
+        this.id
       );
 
       if (this.clickFeatures) {

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -39,17 +39,17 @@ export class MyMap extends LitElement {
   static styles = css`
     :host {
       display: block;
-      width: 800px;
-      height: 800px;
+      width: 500px;
+      height: 500px;
       position: relative;
     }
-    #map {
+    .map {
       height: 100%;
       opacity: 0;
       transition: opacity 0.25s;
       overflow: hidden;
     }
-    #map:focus {
+    .map:focus {
       outline: #d3d3d3 solid 0.15em;
     }
     .ol-control button {
@@ -77,6 +77,9 @@ export class MyMap extends LitElement {
   `;
 
   // configurable component properties
+  @property({ type: String })
+  id = "map";
+
   @property({ type: Number })
   latitude = 51.507351;
 
@@ -174,7 +177,7 @@ export class MyMap extends LitElement {
 
   // runs after the initial render
   firstUpdated() {
-    const target = this.renderRoot.querySelector("#map") as HTMLElement;
+    const target = this.renderRoot.querySelector(`#${this.id}`) as HTMLElement;
 
     const useVectorTiles =
       !this.disableVectorTiles && Boolean(this.osVectorTilesApiKey);
@@ -462,7 +465,7 @@ export class MyMap extends LitElement {
   render() {
     return html`<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
       <link rel="stylesheet" href="https://cdn.skypack.dev/ol@^6.6.1/ol.css" />
-      <div id="map" tabindex="0" />`;
+      <div id="${this.id}" class="map" tabindex="0" />`;
   }
 
   // unmount the map

--- a/src/my-map.ts
+++ b/src/my-map.ts
@@ -39,8 +39,8 @@ export class MyMap extends LitElement {
   static styles = css`
     :host {
       display: block;
-      width: 500px;
-      height: 500px;
+      width: 800px;
+      height: 800px;
       position: relative;
     }
     .map {
@@ -410,12 +410,12 @@ export class MyMap extends LitElement {
       getFeaturesAtPoint(
         fromLonLat([this.longitude, this.latitude]),
         this.osFeaturesApiKey,
-        this.id
+        false
       );
 
       if (this.clickFeatures) {
         map.on("singleclick", (e) => {
-          getFeaturesAtPoint(e.coordinate, this.osFeaturesApiKey);
+          getFeaturesAtPoint(e.coordinate, this.osFeaturesApiKey, true);
         });
       }
 

--- a/src/os-features.ts
+++ b/src/os-features.ts
@@ -34,7 +34,11 @@ export function makeFeatureLayer(color: string, featureFill: boolean) {
  * @param coord - xy coordinate
  * @param apiKey - Ordnance Survey Features API key, sign up here: https://osdatahub.os.uk/plans
  */
-export function getFeaturesAtPoint(coord: Array<number>, apiKey: any) {
+export function getFeaturesAtPoint(
+  coord: Array<number>,
+  apiKey: any,
+  mapId?: string
+) {
   const xml = `
     <ogc:Filter>
       <ogc:Contains>
@@ -68,6 +72,7 @@ export function getFeaturesAtPoint(coord: Array<number>, apiKey: any) {
     .then((response) => response.json())
     .then((data) => {
       if (!data.features.length) return;
+      console.log(`fetched features ${mapId}`, data);
 
       const properties = data.features[0].properties,
         validKeys = ["TOID", "DescriptiveGroup"];
@@ -82,6 +87,9 @@ export function getFeaturesAtPoint(coord: Array<number>, apiKey: any) {
         featureProjection: "EPSG:3857",
       });
 
+      console.log(`processed features ${mapId}`, features);
+
+      // featureSource.clear();
       features.forEach((feature) => {
         const id = feature.getProperties().TOID;
         const existingFeature = featureSource.getFeatureById(id);
@@ -92,6 +100,8 @@ export function getFeaturesAtPoint(coord: Array<number>, apiKey: any) {
           feature.setId(id);
           featureSource.addFeature(feature);
         }
+
+        console.log(`featureSource ${mapId}`, featureSource.getFeatures());
       });
 
       outlineSource.clear();
@@ -104,6 +114,8 @@ export function getFeaturesAtPoint(coord: Array<number>, apiKey: any) {
           }, null)
         )
       );
+
+      console.log(`outlineSource ${mapId}`, outlineSource.getFeatures());
     })
     .catch((error) => console.log(error));
 }


### PR DESCRIPTION
**working solution:**
- add an `id` property so we can set a custom id on `<my-map />` element, defaults to "map" as before
- clear the featureSource upfront when only `showFeaturesAtPoint` is enabled, which should prevent prior query results from persisting in the layer. if `showFeaturesAtPoint` && `clickFeatures` are enabled (don't know of any prod uses of this yet), then we don't clear the source as before to allow for selecting/deselecting features on click
- clear the drawingSource upfront for _both_ cases: when we want to start drawing fresh AND when we want to load a previously drawn polygon into the drawingSource to modify. previously, we only cleared it in the case of starting a fresh drawing
 
**dugging notes:**
update `index.html` to something like this:
```html
<body>
  <div style="display: flex; flex-direction: column;">
    <div style="margin-bottom: 1em">
      <my-map showFeaturesAtPoint latitude="51.507351" longitude="-0.127758" id="map-1" />
    </div>
    <div>
      <my-map showFeaturesAtPoint latitude="51.506351" longitude="-0.124758" id="map-2" />
    </div>
  </div>
</body>
```

in short: when rendering the component multiple times on a page with different props, each instance reflects the layer data of the other -  some props sync unexpectedly (ie `showFeaturesAtPoint`, `drawMode`), and others do not (`featureColor`, etc).

expected behavior is for each instance of the component to exclusively reflects its' own props & it's own layer data based on those props (eg only the feature that intersects with its' unique lat/lng). 

this can be reproduced in PlanX by selecting an address, going 'back' to change the address, and then seeing two highlighted features on the FindProperty map

things i learned: 
- "layers can only be added to a single map" ([openlayers docs](https://github.com/openlayers/openlayers/blob/main/changelog/upgrade-notes.md#layers-can-only-be-added-to-a-single-map)) 
  - so even though these index.html map instances have unique ids and different props, `outlineLayer`, `drawingLayer`, etc are still shared/synced between them. Here's related threads/issues: https://github.com/openlayers/openlayers/issues/10764#issuecomment-596259650, https://stackoverflow.com/questions/63267102/how-can-i-assign-a-unique-identifier-to-openlayers-layers
- since we're experiencing the synced layer data in planx, that indicates that we might have multiple maps rendering on top of one another, or while the map itself re-draws after receiving new props, it's data layer hasn't actually cleared - these working solutions should help that :crossed_fingers: 