### PR TITLE
fix: display snaps on first render if zoom within threshold

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     />
   </head>
   <body>
-    <my-map zoom="18" maxZoom="23" drawMode drawPointer="dot" id="example-map" />
+    <my-map zoom="20" maxZoom="23" drawMode drawPointer="dot" id="example-map" />
 
     <script>
       const map = document.querySelector("my-map");


### PR DESCRIPTION
Previosly, we'd only render snaps after the map moves (zoom, pan, etc) - this change makes snaps visible on the first render before any interactions if other conditions are met (`drawMode` is enabled, `zoom` is greater than or equal to 20)

