### PR TITLE
`pnpm i` to bring lockfile up to date with package.json

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,14 +2,14 @@ lockfileVersion: 5.3
 
 specifiers:
   '@turf/union': ^6.5.0
-  '@types/node': ^16.4.13
+  '@types/node': ^17.0.7
   husky: ^7.0.1
   lint-staged: ^12.0.3
   lit: ^2.0.0-rc.2
   ol: ^6.9.0
   ol-mapbox-style: ^6.4.1
   prettier: ^2.3.2
-  rambda: ^6.9.0
+  rambda: ^7.0.1
   typescript: ^4.3.5
   vite: ^2.4.4
 
@@ -18,10 +18,10 @@ dependencies:
   lit: 2.0.0-rc.2
   ol: 6.9.0
   ol-mapbox-style: 6.4.1_ol@6.9.0
-  rambda: 6.9.0
+  rambda: 7.0.3
 
 devDependencies:
-  '@types/node': 16.4.13
+  '@types/node': 17.0.21
   husky: 7.0.1
   lint-staged: 12.1.2
   prettier: 2.3.2
@@ -97,8 +97,8 @@ packages:
       polygon-clipping: 0.15.3
     dev: false
 
-  /@types/node/16.4.13:
-    resolution: {integrity: sha512-bLL69sKtd25w7p1nvg9pigE4gtKVpGTPojBFLMkGHXuUgap2sLqQt2qUnqmVCDfzGUL0DRNZP+1prIZJbMeAXg==}
+  /@types/node/17.0.21:
+    resolution: {integrity: sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==}
     dev: true
 
   /@types/trusted-types/1.0.6:
@@ -307,6 +307,7 @@ packages:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -645,8 +646,8 @@ packages:
     resolution: {integrity: sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==}
     dev: false
 
-  /rambda/6.9.0:
-    resolution: {integrity: sha512-yosVdGg1hNGkXPzqGiOYNEpXKjEOxzUCg2rB0l+NKdyCaSf4z+i5ojbN0IqDSezMMf71YEglI+ZUTgTffn5afw==}
+  /rambda/7.0.3:
+    resolution: {integrity: sha512-vRkFoukpx9PTmYyOjMZ6+anbDI9BrjaAepigsSOVQcgy7dZKMHM26m1/r8BvegeBCM8qBwr1m/+rufgNKRrofw==}
     dev: false
 
   /rbush/3.0.1:
@@ -833,6 +834,7 @@ packages:
 
   /tiny-worker/2.3.0:
     resolution: {integrity: sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==}
+    requiresBuild: true
     dependencies:
       esm: 3.2.25
     dev: false


### PR DESCRIPTION
I just ran `pnpm i` so that the pnpm-lock.yaml is up to date with the deps specified in package.json

<img width="1064" alt="Screenshot 2022-02-24 at 17 40 45" src="https://user-images.githubusercontent.com/601961/155631637-c26a21e5-89a5-4090-900a-da54ed636166.png">

not sure what happened with the commit name and description but if it's a squash and merge I suppose they don't matter