### PR TITLE
feat: address-autocomplete supports a default value

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,10 +25,13 @@
       <div style="margin-bottom:1em;">
         <!-- 
           Examples (as of March 2022):
-          SE5 OHU (Southwark): default/"normal" postcode example, fetches 65 LPI addresses
+          SE5 OHU (Southwark): default/"standard" postcode example, fetches 65 LPI addresses
           SE19 1NT (Lambeth): 56 DPA addresses -> 128 LPI addresses (87 "approved"), now requires paginated fetch
           HP11 1BR (Bucks): 0 addresses, shows "No addresses found in postcode" error message
           HP11 1BC (Bucks): valid postcode according to npm package but not OS, shows OS error message
+
+          Example with default value (used for planx "change" & "back" button behavior):
+          <address-autocomplete postcode="SE5 0HU" id="example-autocomplete" initialAddress="75, COBOURG ROAD, LONDON" />
         -->
         <address-autocomplete postcode="SE5 0HU" id="example-autocomplete" />
       </div>

--- a/src/components/address-autocomplete/index.ts
+++ b/src/components/address-autocomplete/index.ts
@@ -25,6 +25,9 @@ export class AddressAutocomplete extends LitElement {
   label = "Select an address";
 
   @property({ type: String })
+  initialAddress = "";
+
+  @property({ type: String })
   osPlacesApiKey = import.meta.env.VITE_APP_OS_PLACES_API_KEY || "";
 
   // internal reactive state
@@ -62,6 +65,7 @@ export class AddressAutocomplete extends LitElement {
       id: this.id,
       required: true,
       source: this._options,
+      defaultValue: this.initialAddress,
       showAllValues: true,
       tNoResults: () => "No addresses found",
       onConfirm: (option: any) => {
@@ -124,7 +128,8 @@ export class AddressAutocomplete extends LitElement {
               );
             });
 
-          this._options.sort((a, b) => a.localeCompare(b));
+          const collator = new Intl.Collator([], { numeric: true });
+          this._options.sort((a, b) => collator.compare(a, b));
         }
 
         // fetch next page of results if they exist


### PR DESCRIPTION
ability to set an `initialAddress` prop on the web component, which is then passed to accessible-autocomplete's `defaultValue` option: https://github.com/alphagov/accessible-autocomplete. 

this will enable us to show the prior selected address when "going back" or "changing" your site address in planx. 

since our `initialAddress` will only ever be one that was selected prior, we can assume that we already have the full address record stored in the passport/state from a prior event dispatch, and don't need to fire a new one on initial render.

small bonus of improved options sorting in the dropdown - before address "103..." would show up before "47..." etc.