### PR TITLE
fix: postcode-search & address-autocomplete should set tabindex="0"

### DIFF
--- a/src/components/postcode-search/index.ts
+++ b/src/components/postcode-search/index.ts
@@ -126,6 +126,7 @@ export class PostcodeSearch extends LitElement {
           @input=${this._onInputChange}
           @blur=${this._onBlur}
           @keyup=${this._onKeyUp}
+          tabindex="0"
         />
       </div>`;
   }


### PR DESCRIPTION
am experiencing some unexpected screenreader behavior during [planx integration](https://github.com/theopensystemslab/planx-new/pull/887), hoping `tabindex="0"` will smooth it out! we were already setting `tabindex` on the main map div and that component is read out as expected by my screenreader, so I'm fairly hopeful here. 

this [2014(!) blog](https://marcysutton.com/accessibility-and-the-shadow-dom) reassures that elements rendered in the shadow DOM (as these web components are when integrated into our React frontend) should simply be part of "one happy tree" as far as screenreaders are concerned :deciduous_tree:

a few other minor fixes here too:
- clarify types & code comments
- better error handling