### PR TITLE
feat: Allow autocomplete to be styled from parent

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,22 @@
       href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400;600&display=swap"
       rel="stylesheet"
     />
+    <!-- Examples of available style options for address-autocomplete -->
+    <!-- <style>
+      address-autocomplete {
+        --autocomplete__input__padding: 6px 12px 7px 12px;
+        --autocomplete__input__font-size: 15px;
+        --autocomplete__input__height: 50px;
+        --autocomplete__dropdown-arrow-down__top: 16px;
+        --autocomplete__dropdown-arrow-down__z-index: 2;
+        --autocomplete__option__font-size: 15px;
+        --autocomplete__option__padding: 6px 12px 7px 12px;
+        --autocomplete__menu__max-height: 336px;
+        --autocomplete__option__border-bottom: solid 1px grey;
+        --autocomplete__option__hover-border-color: pink;
+        --autocomplete__option__hover-background-color: pink;
+      }
+    </style> -->
   </head>
   <body>
     <div style="display:flex;flex-direction:column;">

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
       rel="stylesheet"
     />
     <!-- Examples of available style options for address-autocomplete -->
-    <style>
+    <!-- <style>
       address-autocomplete {
         --autocomplete__input__padding: 6px 12px 7px 12px;
         --autocomplete__input__font-size: 15px;
@@ -28,7 +28,7 @@
         --autocomplete__option__hover-background-color: rgb(0, 99, 96);
         --autocomplete__font-family: "Courier New";
       }
-    </style>
+    </style> -->
   </head>
   <body>
     <div style="display:flex;flex-direction:column;">

--- a/index.html
+++ b/index.html
@@ -24,8 +24,9 @@
         --autocomplete__option__padding: 6px 12px 7px 12px;
         --autocomplete__menu__max-height: 336px;
         --autocomplete__option__border-bottom: solid 1px grey;
-        --autocomplete__option__hover-border-color: pink;
-        --autocomplete__option__hover-background-color: pink;
+        --autocomplete__option__hover-border-color: rgb(0, 99, 96);
+        --autocomplete__option__hover-background-color: rgb(0, 99, 96);
+        --autocomplete__font-family: "Courier New";
       }
     </style> -->
   </head>

--- a/src/components/address-autocomplete/index.ts
+++ b/src/components/address-autocomplete/index.ts
@@ -67,6 +67,7 @@ export class AddressAutocomplete extends LitElement {
       source: this._options,
       defaultValue: this.initialAddress,
       showAllValues: true,
+      displayMenu: "overlay",
       tNoResults: () => "No addresses found",
       onConfirm: (option: any) => {
         this._selectedAddress = this._addressesInPostcode.filter(
@@ -170,7 +171,11 @@ export class AddressAutocomplete extends LitElement {
             href="https://cdn.jsdelivr.net/npm/accessible-autocomplete@2.0.4/dist/accessible-autocomplete.min.css"
           />
           <label class="govuk-label" htmlFor=${this.id}> ${this.label} </label>
-          <div id="${this.id}-container" role="status"></div>`;
+          <div
+            id="${this.id}-container"
+            role="status"
+            spellcheck="false"
+          ></div>`;
   }
 
   /**

--- a/src/components/address-autocomplete/styles.scss
+++ b/src/components/address-autocomplete/styles.scss
@@ -2,10 +2,21 @@
 // @import "accessible-autocomplete";
 
 :host {
+  $font-family: var(
+    --autocomplete__font-family,
+    "GDS Transport",
+    arial,
+    sans-serif
+  );
   $font-size: var(--autocomplete__input__font-size, 19px);
   $input-height: var(--autocomplete__input__height, 35px);
 
+  .govuk-label {
+    font-family: $font-family;
+  }
+
   .autocomplete__input {
+    font-family: $font-family;
     font-size: $font-size;
     height: $input-height;
     padding: var(--autocomplete__input__padding, 5px 34px 5px 5px);
@@ -19,6 +30,7 @@
   }
 
   .autocomplete__option {
+    font-family: $font-family;
     font-size: $font-size;
     padding: var(--autocomplete__option__padding, 5px);
     border-bottom: var(
@@ -39,10 +51,4 @@
   .autocomplete__menu {
     max-height: var(--autocomplete__menu__max-height, 342px);
   }
-}
-
-// makes listbox items consistent with label font, etc
-ul,
-li {
-  font-family: Inter, Helvetica, sans-serif;
 }

--- a/src/components/address-autocomplete/styles.scss
+++ b/src/components/address-autocomplete/styles.scss
@@ -1,6 +1,46 @@
 @import "node_modules/govuk-frontend/govuk/all";
 // @import "accessible-autocomplete";
 
+:host {
+  $font-size: var(--autocomplete__input__font-size, 19px);
+  $input-height: var(--autocomplete__input__height, 35px);
+
+  .autocomplete__input {
+    font-size: $font-size;
+    height: $input-height;
+    padding: var(--autocomplete__input__padding, 5px 34px 5px 5px);
+  }
+
+  .autocomplete__dropdown-arrow-down {
+    z-index: var(--autocomplete__dropdown-arrow-down__z-index, -1);
+    // Ensure the down arrow is vertically centred
+    $arrow-down-height: 17px;
+    top: calc(($input-height - $arrow-down-height) / 2);
+  }
+
+  .autocomplete__option {
+    font-size: $font-size;
+    padding: var(--autocomplete__option__padding, 5px);
+    border-bottom: var(
+      --autocomplete__option__border-bottom,
+      solid 1px #b1b4b6
+    );
+
+    &:hover,
+    &:focus {
+      border-color: var(--autocomplete__option__hover-border-color, #1d70b8);
+      background-color: var(
+        --autocomplete__option__hover-background-color,
+        #1d70b8
+      );
+    }
+  }
+
+  .autocomplete__menu {
+    max-height: var(--autocomplete__menu__max-height, 342px);
+  }
+}
+
 // makes listbox items consistent with label font, etc
 ul,
 li {

--- a/src/components/address-autocomplete/styles.scss
+++ b/src/components/address-autocomplete/styles.scss
@@ -37,7 +37,6 @@
       --autocomplete__option__border-bottom,
       solid 1px #b1b4b6
     );
-
     &:hover,
     &:focus {
       border-color: var(--autocomplete__option__hover-border-color, #1d70b8);


### PR DESCRIPTION
This PR allows certain properties of the `address-autocomplete` component to be styled from a parent. The properties that have been given variables should marry up with any that we need to match the PlanX style.

Lit Docs - https://lit.dev/docs/components/styles/#theming

**Example with Lambeth primary colour**

![image](https://user-images.githubusercontent.com/20502206/159706602-7564ab94-b49b-43a5-bcfe-d14db95e5fa8.png)

**To Do**
- [ ] Document these new properties with more than just a comment in the code