### PR TITLE
fix: autocomplete container shouldn't have tabindex if input does

### DIFF
--- a/src/components/address-autocomplete/index.ts
+++ b/src/components/address-autocomplete/index.ts
@@ -179,7 +179,6 @@ export class AddressAutocomplete extends LitElement {
           <div
             id="${this.id}-container"
             role="status"
-            tabindex="0"
             spellcheck="false"
           ></div>`;
   }


### PR DESCRIPTION
the input is automatically rendered with a tabindex, so adding one on the container div was actually a mistake that will require two-tabs to be able to focus & start typing!