### PR TITLE
feat: Improve style of autocomplete

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <!-- Examples of available style options for address-autocomplete -->
     <!-- <style>
       address-autocomplete {
-        --autocomplete__input__padding: 6px 12px 7px 12px;
+        --autocomplete__input__padding: 6px 40px 7px 12px;
         --autocomplete__input__font-size: 15px;
         --autocomplete__input__height: 50px;
         --autocomplete__dropdown-arrow-down__top: 16px;
@@ -39,7 +39,7 @@
       <div style="margin-bottom:1em">
         <postcode-search hintText="Optional hint text shows up here" id="example-postcode" />
       </div>
-      <div style="margin-bottom:1em;">
+      <div style="margin-bottom:1em; background-color: white;">
         <!-- 
           Examples (as of March 2022):
           SE5 OHU (Southwark): default/"standard" postcode example, fetches 65 LPI addresses
@@ -50,7 +50,7 @@
           Example with default value (used for planx "change" & "back" button behavior):
           <address-autocomplete postcode="SE5 0HU" id="example-autocomplete" initialAddress="75, COBOURG ROAD, LONDON" />
         -->
-        <address-autocomplete postcode="SE5 0HU" id="example-autocomplete" />
+        <address-autocomplete postcode="SE5 0HU" id="example-autocomplete" arrowStyle="light"/>
       </div>
     </div>
     <script>

--- a/src/components/address-autocomplete/index.ts
+++ b/src/components/address-autocomplete/index.ts
@@ -9,6 +9,8 @@ type Address = {
   LPI: any;
 };
 
+type ArrowStyleEnum = "default" | "light";
+
 @customElement("address-autocomplete")
 export class AddressAutocomplete extends LitElement {
   // ref https://github.com/e111077/vite-lit-element-ts-sass/issues/3
@@ -31,7 +33,7 @@ export class AddressAutocomplete extends LitElement {
   osPlacesApiKey = import.meta.env.VITE_APP_OS_PLACES_API_KEY || "";
 
   @property({ type: String })
-  arrowStyle = "default";
+  arrowStyle: ArrowStyleEnum = "default";
 
   // internal reactive state
   @state()

--- a/src/components/address-autocomplete/index.ts
+++ b/src/components/address-autocomplete/index.ts
@@ -30,6 +30,9 @@ export class AddressAutocomplete extends LitElement {
   @property({ type: String })
   osPlacesApiKey = import.meta.env.VITE_APP_OS_PLACES_API_KEY || "";
 
+  @property({ type: String })
+  arrowStyle = "default";
+
   // internal reactive state
   @state()
   private _totalAddresses: number | undefined = undefined;
@@ -57,6 +60,10 @@ export class AddressAutocomplete extends LitElement {
     super.disconnectedCallback();
   }
 
+  getLightDropdownArrow() {
+    return '<svg class="autocomplete__dropdown-arrow-down" style="height: 17px;" viewBox="0 0 512 512" ><path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9  c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3  z"/></svg>';
+  }
+
   // called after the initial render
   firstUpdated() {
     // https://github.com/alphagov/accessible-autocomplete
@@ -68,6 +75,8 @@ export class AddressAutocomplete extends LitElement {
       defaultValue: this.initialAddress,
       showAllValues: true,
       displayMenu: "overlay",
+      dropdownArrow:
+        this.arrowStyle === "light" ? this.getLightDropdownArrow : undefined,
       tNoResults: () => "No addresses found",
       onConfirm: (option: string) => {
         this._selectedAddress = this._addressesInPostcode.filter(

--- a/src/components/address-autocomplete/styles.scss
+++ b/src/components/address-autocomplete/styles.scss
@@ -10,6 +10,7 @@
   );
   $font-size: var(--autocomplete__input__font-size, 19px);
   $input-height: var(--autocomplete__input__height, 35px);
+  $arrow-down-z-index: var(--autocomplete__dropdown-arrow-down__z-index, 1);
 
   .govuk-label {
     font-family: $font-family;
@@ -20,10 +21,13 @@
     font-size: $font-size;
     height: $input-height;
     padding: var(--autocomplete__input__padding, 5px 34px 5px 5px);
+    // Ensure arrow is visible on white background, but behind the input so the click interaction works
+    // https://github.com/alphagov/accessible-autocomplete/issues/351
+    z-index: calc($arrow-down-z-index + 1);
   }
 
   .autocomplete__dropdown-arrow-down {
-    z-index: var(--autocomplete__dropdown-arrow-down__z-index, -1);
+    z-index: $arrow-down-z-index;
     // Ensure the down arrow is vertically centred
     $arrow-down-height: 17px;
     top: calc(($input-height - $arrow-down-height) / 2);
@@ -37,14 +41,16 @@
       --autocomplete__option__border-bottom,
       solid 1px #b1b4b6
     );
-    &:hover,
-    &:focus {
-      border-color: var(--autocomplete__option__hover-border-color, #1d70b8);
-      background-color: var(
-        --autocomplete__option__hover-background-color,
-        #1d70b8
-      );
-    }
+  }
+
+  .autocomplete__option--focused,
+  .autocomplete__option:hover,
+  .autocomplete__option--focused & .autocomplete__option:hover {
+    border-color: var(--autocomplete__option__hover-border-color, #1d70b8);
+    background-color: var(
+      --autocomplete__option__hover-background-color,
+      #1d70b8
+    );
   }
 
   .autocomplete__menu {


### PR DESCRIPTION
A few little fixes and improvements.

 - Down arrow is visible on white background, and is now clickable (only to open, as original component works)
   - Relates to this issue https://github.com/alphagov/accessible-autocomplete/issues/351
 - New "light" down arrow option which is a little nicer looking 💅 
 - Style doesn't break when focus and hover interact (see below)
   - There's still a `:focus-visible` ring, see issue here - https://github.com/alphagov/accessible-autocomplete/issues/73  


![chrome-capture (12)](https://user-images.githubusercontent.com/20502206/159909639-c629aa30-6952-4b0d-bad2-3d011e973cc6.gif)
