### PR TITLE
feat: Enable static or responsive label on autocomplete

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,8 +13,9 @@
       rel="stylesheet"
     />
     <!-- Examples of available style options for address-autocomplete -->
-    <!-- <style>
+    <style>
       address-autocomplete {
+        /* --autocomplete__label__font-size: 25px; */
         --autocomplete__input__padding: 6px 40px 7px 12px;
         --autocomplete__input__font-size: 15px;
         --autocomplete__input__height: 50px;
@@ -28,7 +29,7 @@
         --autocomplete__option__hover-background-color: rgb(0, 99, 96);
         --autocomplete__font-family: "Courier New";
       }
-    </style> -->
+    </style>
   </head>
   <body>
     <div style="display:flex;flex-direction:column;">
@@ -50,7 +51,7 @@
           Example with default value (used for planx "change" & "back" button behavior):
           <address-autocomplete postcode="SE5 0HU" id="example-autocomplete" initialAddress="75, COBOURG ROAD, LONDON" />
         -->
-        <address-autocomplete postcode="SE5 0HU" id="example-autocomplete" arrowStyle="light"/>
+        <address-autocomplete postcode="SE5 0HU" id="example-autocomplete" arrowStyle="light" labelStyle="static"/>
       </div>
     </div>
     <script>

--- a/index.html
+++ b/index.html
@@ -13,9 +13,9 @@
       rel="stylesheet"
     />
     <!-- Examples of available style options for address-autocomplete -->
-    <style>
+    <!-- <style>
       address-autocomplete {
-        /* --autocomplete__label__font-size: 25px; */
+        --autocomplete__label__font-size: 25px;
         --autocomplete__input__padding: 6px 40px 7px 12px;
         --autocomplete__input__font-size: 15px;
         --autocomplete__input__height: 50px;
@@ -29,7 +29,7 @@
         --autocomplete__option__hover-background-color: rgb(0, 99, 96);
         --autocomplete__font-family: "Courier New";
       }
-    </style>
+    </style> -->
   </head>
   <body>
     <div style="display:flex;flex-direction:column;">

--- a/src/components/address-autocomplete/index.ts
+++ b/src/components/address-autocomplete/index.ts
@@ -168,7 +168,7 @@ export class AddressAutocomplete extends LitElement {
       .catch((error) => console.log(error));
   }
 
-  getLabelClasses() {
+  _getLabelClasses() {
     let styles = "govuk-label";
     if (this.labelStyle === "static") {
       styles += " govuk-label--static";
@@ -198,7 +198,7 @@ export class AddressAutocomplete extends LitElement {
             rel="stylesheet"
             href="https://cdn.jsdelivr.net/npm/accessible-autocomplete@2.0.4/dist/accessible-autocomplete.min.css"
           />
-          <label class=${this.getLabelClasses()} htmlFor=${this.id}
+          <label class=${this._getLabelClasses()} htmlFor=${this.id}
             >${this.label}</label
           >
           <div

--- a/src/components/address-autocomplete/index.ts
+++ b/src/components/address-autocomplete/index.ts
@@ -10,6 +10,7 @@ type Address = {
 };
 
 type ArrowStyleEnum = "default" | "light";
+type LabelStyleEnum = "responsive" | "static";
 
 @customElement("address-autocomplete")
 export class AddressAutocomplete extends LitElement {
@@ -34,6 +35,9 @@ export class AddressAutocomplete extends LitElement {
 
   @property({ type: String })
   arrowStyle: ArrowStyleEnum = "default";
+
+  @property({ type: String })
+  labelStyle: LabelStyleEnum = "responsive";
 
   // internal reactive state
   @state()
@@ -164,6 +168,14 @@ export class AddressAutocomplete extends LitElement {
       .catch((error) => console.log(error));
   }
 
+  getLabelClasses() {
+    let styles = "govuk-label";
+    if (this.labelStyle === "static") {
+      styles += " govuk-label--static";
+    }
+    return styles;
+  }
+
   render() {
     // handle various error states
     let errorMessage;
@@ -186,7 +198,9 @@ export class AddressAutocomplete extends LitElement {
             rel="stylesheet"
             href="https://cdn.jsdelivr.net/npm/accessible-autocomplete@2.0.4/dist/accessible-autocomplete.min.css"
           />
-          <label class="govuk-label" htmlFor=${this.id}>${this.label}</label>
+          <label class=${this.getLabelClasses()} htmlFor=${this.id}
+            >${this.label}</label
+          >
           <div
             id="${this.id}-container"
             role="status"

--- a/src/components/address-autocomplete/styles.scss
+++ b/src/components/address-autocomplete/styles.scss
@@ -16,6 +16,10 @@
     font-family: $font-family;
   }
 
+  .govuk-label--static {
+    font-size: var(--autocomplete__label__font-size, 19px);
+  }
+
   .autocomplete__input {
     font-family: $font-family;
     font-size: $font-size;


### PR DESCRIPTION
Realised during Friday's show and tell that the label font size is 19px on PlanX when it should be 18px!

By default, the `govuk-label` class takes into account the following breakpoints - https://github.com/alphagov/govuk-frontend/blob/v4.0.0/src/govuk/settings/_media-queries.scss#L10-L14

This means it's not quite as simple as overwriting the font-size and setting a default, as this would have the side effect of breaking the responsiveness if anybody else wanted to use the component.