### PR TITLE
fix: Further a11y fixes for autocomplete

### DIFF
--- a/src/components/address-autocomplete/index.ts
+++ b/src/components/address-autocomplete/index.ts
@@ -186,12 +186,8 @@ export class AddressAutocomplete extends LitElement {
             rel="stylesheet"
             href="https://cdn.jsdelivr.net/npm/accessible-autocomplete@2.0.4/dist/accessible-autocomplete.min.css"
           />
-          <label class="govuk-label" htmlFor=${this.id}>${this.label}</label>
-          <div
-            id="${this.id}-container"
-            role="status"
-            spellcheck="false"
-          ></div>`;
+          <label class="govuk-label" for=${this.id}>${this.label}</label>
+          <div id="${this.id}-container" spellcheck="false"></div>`;
   }
 
   /**


### PR DESCRIPTION
See following message (28/03/22) - 

> “We have noticed that the label for the autocomplete is not marked up correctly and comes across as unlabelled, this is due to the htmlfor and should just be ‘for’
> 
> `<label class="govuk-label" htmlfor="address-autocomplete"><!--?lit$21620639537$-->Select an address</label>`
>
> `<label class="govuk-label" for="address-autocomplete"><!--?lit$21620639537$-->Select an address</label>`
>
> As for functionality for the autocomplete this is much better but there is a slight issue where the status has been applied to an outside div which is resulting in the options all reading out in one go. This needs to be removed.
>
> `#address-autocomplete-container`
>
>`<div role="status" spellcheck="false" id="address-autocomplete-container"><div class="autocomplete__wrapper">`
>
>Please let me know when these are resolved and I can update the report and send over.”