### PR TITLE
v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The minor version will be incremented upon a breaking change and the patch version will be
 incremented for features.
 
+## [0.5.3] - 2022-03-28
+- fix: Re-enable `labelStyle` property ([#133](https://github.com/theopensystemslab/map/pull/130))
+
 ## [0.5.2] - 2022-03-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opensystemslab/map",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "license": "OGL-UK-3.0",
   "private": false,
   "repository": {


### PR DESCRIPTION
## [0.5.3] - 2022-03-28
- fix: Re-enable `labelStyle` property ([#133](https://github.com/theopensystemslab/map/pull/130))