### PR TITLE
fix: postcode-search improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
       // --- POSTCODE SEARCH --- //
       const search = document.querySelector("postcode-search");
 
-      search.addEventListener("postcodeValidated", ({ detail }) => {
+      search.addEventListener("postcodeChange", ({ detail }) => {
         console.debug({ detail });
       });
 

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
       href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400;600&display=swap"
       rel="stylesheet"
     />
-    <!-- Examples of available style options for address-autocomplete -->
+    <!-- Examples of available style options for postcode-search & address-autocomplete -->
     <!-- <style>
       address-autocomplete {
         --autocomplete__label__font-size: 25px;
@@ -28,6 +28,14 @@
         --autocomplete__option__hover-border-color: rgb(0, 99, 96);
         --autocomplete__option__hover-background-color: rgb(0, 99, 96);
         --autocomplete__font-family: "Courier New";
+      }
+
+      postcode-search {
+        --postcode__font-family: "Times New Roman";
+        --postcode__font-size: 18px;
+        --postcode__input__font-size: 24px;
+        --postcode__input__padding: 30px 10px;
+        --postcode__input__height: 60px;
       }
     </style> -->
   </head>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ specifiers:
   '@turf/union': ^6.5.0
   '@types/node': ^17.0.7
   accessible-autocomplete: ^2.0.4
-  govuk-frontend: ^3.14.0
+  govuk-frontend: ^4.0.1
   husky: ^7.0.1
   lint-staged: ^12.0.3
   lit: ^2.0.0-rc.2
@@ -21,7 +21,7 @@ specifiers:
 dependencies:
   '@turf/union': 6.5.0
   accessible-autocomplete: 2.0.4
-  govuk-frontend: 3.14.0
+  govuk-frontend: 4.0.1
   lit: 2.0.0-rc.2
   ol: 6.9.0
   ol-mapbox-style: 7.1.1
@@ -443,8 +443,8 @@ packages:
       is-glob: 4.0.3
     dev: true
 
-  /govuk-frontend/3.14.0:
-    resolution: {integrity: sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA==}
+  /govuk-frontend/4.0.1:
+    resolution: {integrity: sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ==}
     engines: {node: '>= 4.2.0'}
     dev: false
 

--- a/src/components/address-autocomplete/index.ts
+++ b/src/components/address-autocomplete/index.ts
@@ -66,7 +66,7 @@ export class AddressAutocomplete extends LitElement {
     super.disconnectedCallback();
   }
 
-  getLightDropdownArrow() {
+  _getLightDropdownArrow() {
     return '<svg class="autocomplete__dropdown-arrow-down" style="height: 17px;" viewBox="0 0 512 512" ><path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9  c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3  z"/></svg>';
   }
 
@@ -82,7 +82,7 @@ export class AddressAutocomplete extends LitElement {
       showAllValues: true,
       displayMenu: "overlay",
       dropdownArrow:
-        this.arrowStyle === "light" ? this.getLightDropdownArrow : undefined,
+        this.arrowStyle === "light" ? this._getLightDropdownArrow : undefined,
       tNoResults: () => "No addresses found",
       onConfirm: (option: string) => {
         this._selectedAddress = this._addressesInPostcode.filter(

--- a/src/components/postcode-search/index.ts
+++ b/src/components/postcode-search/index.ts
@@ -94,13 +94,11 @@ export class PostcodeSearch extends LitElement {
   _makeLabel() {
     return this.onlyQuestionOnPage
       ? html`<h1 class="govuk-label-wrapper">
-          <label class="govuk-label govuk-label--l" htmlFor=${this.id}>
+          <label class="govuk-label govuk-label--l" for=${this.id}>
             ${this.label}
           </label>
         </h1>`
-      : html`<label class="govuk-label" htmlFor=${this.id}
-          >${this.label}</label
-        >`;
+      : html`<label class="govuk-label" for=${this.id}>${this.label}</label>`;
   }
 
   render() {

--- a/src/components/postcode-search/index.ts
+++ b/src/components/postcode-search/index.ts
@@ -47,17 +47,17 @@ export class PostcodeSearch extends LitElement {
     if (isValid) {
       this._sanitizedPostcode = toNormalised(input.trim());
       this._postcode = toNormalised(input.trim()) || input;
+      this._showPostcodeError = false;
     } else {
       this._sanitizedPostcode = null;
       this._postcode = input.toUpperCase();
     }
 
-    if (this._sanitizedPostcode) {
-      this._showPostcodeError = false;
-      this.dispatch("postcodeValidated", {
-        postcode: this._sanitizedPostcode,
-      });
-    }
+    // dispatch an event on every input change
+    this.dispatch("postcodeChange", {
+      postcode: this._sanitizedPostcode || input,
+      isValid: isValid,
+    });
   }
 
   _onBlur() {
@@ -75,6 +75,8 @@ export class PostcodeSearch extends LitElement {
   _showError() {
     const errorEl: HTMLElement | null | undefined =
       this.shadowRoot?.querySelector(`#${this.errorId}`);
+
+    // display "none" ensures always present in DOM, which means role="status" will work for screenreaders
     if (errorEl) errorEl.style.display = "none";
     if (errorEl && this._showPostcodeError) errorEl.style.display = "";
 
@@ -106,14 +108,14 @@ export class PostcodeSearch extends LitElement {
       <div class="govuk-form-group">
         ${this._makeLabel()}
         <div id="postcode-hint" class="govuk-hint">${this.hintText}</div>
-        <span
+        <p
           id=${this.errorId}
           class="govuk-error-message"
           style="display:none"
           role="status"
         >
           <span class="govuk-visually-hidden">Error:</span>${this.errorMessage}
-        </span>
+        </p>
         <input
           class="govuk-input govuk-input--width-10"
           id=${this.id}

--- a/src/components/postcode-search/styles.scss
+++ b/src/components/postcode-search/styles.scss
@@ -1,2 +1,28 @@
 @import "node_modules/govuk-frontend/govuk/all";
 // @import "node_modules/govuk-frontend/govuk/components/input/_index.scss";
+
+:host {
+  $font-family: var(
+    --postcode__font-family,
+    "GDS Transport",
+    arial,
+    sans-serif
+  );
+  $font-size: var(--postcode__font-size, 19px);
+  $input-font-size: var(--postcode__input__font-size, 19px);
+  $input-height: var(--postcode__input__height, 35px);
+
+  .govuk-label,
+  .govuk-hint,
+  .govuk-error-message {
+    font-family: $font-family;
+    font-size: $font-size;
+  }
+
+  .govuk-input {
+    font-family: $font-family;
+    font-size: $input-font-size;
+    height: $input-height;
+    padding: var(--postcode__input__padding, 5px 34px 5px 5px);
+  }
+}


### PR DESCRIPTION
- Adjust error message according to new `govuk-frontend` release [change note](https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md#update-the-html-for-error-messages)
- Dispatch an event on input change, rather than only when the postcode is validated - otherwise an integration in planx doesn't know when to (re)hide the address-autocomplete when a valid postcode is changed
- Added basic set of custom style properties ([Lit docs](https://lit.dev/docs/v1/components/styles/#configurable)) we'd likely want to configure/override in planx, following autocomplete example, but nothing too fancy or complex
- Use `for` not `htmlFor` to link label & input