### PR TITLE
Improve accessibility of map component when focusing

### DIFF
--- a/src/components/my-map/styles.scss
+++ b/src/components/my-map/styles.scss
@@ -10,9 +10,10 @@
   opacity: 0;
   transition: opacity 0.25s;
   overflow: hidden;
+  border: #000000 solid 0.15em;
 }
 .map:focus {
-  outline: #d3d3d3 solid 0.15em;
+  outline: #FFDD00 solid 0.25em;
 }
 .ol-control button {
   border-radius: 0 !important;


### PR DESCRIPTION
- The outcome of an accessibility report was that the maps had insufficient highlighting on focus to be distinguishable.
- The contrast ratio is: 1.5:1 (1.4.11 Non-text Contrast (AA): Fail for UI components and graphical objects)
- https://trello.com/c/G9yKOAne/904-insufficient-focus
- This adds a black border around the component and the govuk-focus-colour as the focus outline which should now have enough contrast