### PR TITLE
feat: show features without border & ability to add a custom marker

### DIFF
--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -85,6 +85,9 @@ export class MyMap extends LitElement {
   @property({ type: Boolean })
   featureFill = false;
 
+  @property({ type: Boolean })
+  featureBorderNone = false;
+
   @property({ type: Number })
   featureBuffer = 40;
 
@@ -397,7 +400,8 @@ export class MyMap extends LitElement {
 
       const outlineLayer = makeFeatureLayer(
         this.featureColor,
-        this.featureFill
+        this.featureFill,
+        this.featureBorderNone
       );
       map.addLayer(outlineLayer);
 

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -1,13 +1,15 @@
 import { html, LitElement, unsafeCSS } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { Control, defaults as defaultControls } from "ol/control";
+import { Point } from "ol/geom";
 import { GeoJSON } from "ol/format";
+import { Feature } from "ol/index";
 import { defaults as defaultInteractions } from "ol/interaction";
 import { Vector as VectorLayer } from "ol/layer";
 import Map from "ol/Map";
 import { fromLonLat, transformExtent } from "ol/proj";
 import { Vector as VectorSource } from "ol/source";
-import { Fill, Stroke, Style } from "ol/style";
+import { Circle, Fill, Stroke, Style } from "ol/style";
 import View from "ol/View";
 import { last } from "rambda";
 
@@ -90,6 +92,18 @@ export class MyMap extends LitElement {
 
   @property({ type: Number })
   featureBuffer = 40;
+
+  @property({ type: Boolean })
+  showMarker = false;
+
+  @property({ type: Number })
+  markerLatitude = this.latitude;
+
+  @property({ type: Number })
+  markerLongitude = this.longitude;
+
+  @property({ type: String })
+  markerColor = "#000000";
 
   @property({ type: Object })
   geojsonData = {
@@ -432,6 +446,26 @@ export class MyMap extends LitElement {
           }
         }
       });
+    }
+
+    // show a marker at a point
+    if (this.showMarker) {
+      const markerPoint = new Point(
+        fromLonLat([this.markerLongitude, this.markerLatitude])
+      );
+      const markerLayer = new VectorLayer({
+        source: new VectorSource({
+          features: [new Feature(markerPoint)],
+        }),
+        style: new Style({
+          image: new Circle({
+            radius: 9,
+            fill: new Fill({ color: this.markerColor }),
+          }),
+        }),
+      });
+
+      map.addLayer(markerLayer);
     }
 
     // XXX: force re-render for safari due to it thinking map is 0 height on load

--- a/src/components/my-map/os-features.ts
+++ b/src/components/my-map/os-features.ts
@@ -13,14 +13,20 @@ const featureSource = new VectorSource();
 
 export const outlineSource = new VectorSource();
 
-export function makeFeatureLayer(color: string, featureFill: boolean) {
+export function makeFeatureLayer(
+  color: string,
+  featureFill: boolean,
+  borderNone: boolean
+) {
   return new VectorLayer({
     source: outlineSource,
     style: new Style({
-      stroke: new Stroke({
-        width: 3,
-        color: color,
-      }),
+      stroke: borderNone
+        ? undefined
+        : new Stroke({
+            width: 3,
+            color: color,
+          }),
       fill: new Fill({
         color: featureFill ? hexToRgba(color, 0.2) : hexToRgba(color, 0),
       }),


### PR DESCRIPTION
two styling features to help clarify how we highlight addresses: 
- boolean property `featureBorderNone` to control whether or not to show a border when highlighting an OS Feature that intersects with a point
```<my-map zoom="20" showFeaturesAtPoint featureFill="#fff" featureBorderNone />```
![Screenshot from 2022-07-05 12-58-22](https://user-images.githubusercontent.com/5132349/177314614-d443a643-98e3-4a55-860f-064f0a67caa0.png)

- boolean property `showMarker` to show a marker on the map (defaults to center latitude & longitude), with optional number properties `markerLatitude`, `markerLongitude` to specify a custom latitude & longitude to place the marker at. The marker will default to a black dot, but you can pass a custom hex code or CSS color name to `markerColor`.
```<my-map zoom="20" showMarker />```
![Screenshot from 2022-07-05 13-50-53](https://user-images.githubusercontent.com/5132349/177322486-173a6c75-882e-4b44-bf38-91c35067afce.png)
