### PR TITLE
feat: add basic unit tests for map component

### DIFF
--- a/src/components/address-autocomplete/main.test.ts
+++ b/src/components/address-autocomplete/main.test.ts
@@ -22,16 +22,27 @@ describe("AddressAutocomplete on initial render with valid postcode", async () =
     await window.happyDOM.whenAsyncComplete();
   }, 2500);
 
-  it("renders the autocomplete without a warning", () => {
-    const autocomplete = getShadowRoot("address-autocomplete");
-    expect(autocomplete?.getElementById("autocomplete-vitest-container"))
-      .toBeDefined;
-    expect(autocomplete?.innerHTML).toContain("combobox");
+  it("should render a custom element", () => {
+    const autocomplete = document.body.querySelector("address-autocomplete");
+    expect(autocomplete).toBeTruthy;
+
+    const autocompleteShadowRoot = getShadowRoot("address-autocomplete");
+    expect(autocompleteShadowRoot).toBeTruthy;
+  });
+
+  it("should have an input with autocomplete attributes", () => {
+    const input = getShadowRootEl("address-autocomplete", "input");
+    expect(input).toBeTruthy;
+    expect(input?.getAttribute("role")).toEqual("combobox");
+    expect(input?.getAttribute("type")).toEqual("text");
+    expect(input?.getAttribute("aria-autocomplete")).toEqual("list");
+    expect(input?.getAttribute("aria-expanded")).toEqual("false");
+    expect(input?.getAttribute("autocomplete")).toEqual("off");
   });
 
   it("should have a label with the default text", () => {
     const label = getShadowRootEl("address-autocomplete", "label");
-    expect(label).toBeDefined;
+    expect(label).toBeTruthy;
     expect(label?.className).toContain("govuk-label");
     expect(label?.innerHTML).toContain("Select an address");
   });
@@ -45,8 +56,10 @@ describe("AddressAutocomplete on initial render with valid postcode", async () =
   });
 
   it("should always render the warning message container for screenreaders", () => {
-    const autocomplete = getShadowRoot("address-autocomplete");
-    expect(autocomplete?.getElementById("error-message-container")).toBeDefined;
+    const error = getShadowRoot("address-autocomplete")?.getElementById(
+      "error-message-container"
+    );
+    expect(error).toBeTruthy;
   });
 });
 

--- a/src/components/address-autocomplete/main.test.ts
+++ b/src/components/address-autocomplete/main.test.ts
@@ -22,7 +22,7 @@ describe("AddressAutocomplete on initial render with valid postcode", async () =
     await window.happyDOM.whenAsyncComplete();
   }, 2500);
 
-  it("should render a custom element", () => {
+  it("should render a custom element with a shadow root", () => {
     const autocomplete = document.body.querySelector("address-autocomplete");
     expect(autocomplete).toBeTruthy;
 

--- a/src/components/my-map/main.test.ts
+++ b/src/components/my-map/main.test.ts
@@ -1,30 +1,32 @@
 import type { IWindow } from "happy-dom";
-import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect } from "vitest";
 
-import { getShadowRootEl } from "../../test-utils";
+import { getShadowRoot } from "../../test-utils";
 
-// import "./index";
+import "./index";
 
 declare global {
   interface Window extends IWindow {}
 }
 
-describe.todo("MyMap on initial render with OSM basemap", async () => {
-  // https://stackoverflow.com/questions/61683583/openlayers-6-typeerror-url-createobjecturl-is-not-a-function
-  global.URL.createObjectURL = vi.fn();
-
+describe("MyMap on initial render with OSM basemap", async () => {
   beforeEach(async () => {
     document.body.innerHTML = '<my-map id="map-vitest" disableVectorTiles />';
 
     await window.happyDOM.whenAsyncComplete();
-  }, 1000);
+  }, 2500);
 
-  afterEach(async () => {
-    vi.resetAllMocks();
+  it("should render a custom element with a shadow root", () => {
+    const map = document.body.querySelector("my-map");
+    expect(map).toBeTruthy;
+
+    const mapShadowRoot = getShadowRoot("my-map");
+    expect(mapShadowRoot).toBeTruthy;
   });
 
   it("should be keyboard navigable", () => {
-    const input = getShadowRootEl("my-map", "div");
-    expect(input?.getAttribute("tabindex")).toEqual("0");
+    const map = getShadowRoot("my-map")?.getElementById("map-vitest");
+    expect(map).toBeTruthy;
+    expect(map?.getAttribute("tabindex")).toEqual("0");
   });
 });

--- a/src/components/postcode-search/main.test.ts
+++ b/src/components/postcode-search/main.test.ts
@@ -17,6 +17,11 @@ describe("PostcodeSearch on initial render with default props", async () => {
     await window.happyDOM.whenAsyncComplete();
   }, 1000);
 
+  it("should render a custom element", () => {
+    const input = getShadowRoot("postcode-search");
+    expect(input).toBeTruthy;
+  });
+
   it("should be keyboard navigable", () => {
     const input = getShadowRootEl("postcode-search", "input");
     expect(input?.getAttribute("tabindex")).toEqual("0");
@@ -24,7 +29,7 @@ describe("PostcodeSearch on initial render with default props", async () => {
 
   it("should have a label with the default text", () => {
     const label = getShadowRootEl("postcode-search", "label");
-    expect(label).toBeDefined;
+    expect(label).toBeTruthy;
     expect(label?.innerHTML).toContain("Postcode");
     expect(label?.className).toContain("govuk-label");
   });
@@ -37,9 +42,10 @@ describe("PostcodeSearch on initial render with default props", async () => {
     expect(input?.id).toEqual("postcode-vitest");
   });
 
-  it("should render a visually hidden error message container for screenreaders", () => {
+  it("should always render the error message container for screenreaders", () => {
     const error =
       getShadowRoot("postcode-search")?.getElementById("postcode-error");
+    expect(error).toBeTruthy;
     expect(error?.className).toContain("govuk-error-message");
     expect(error?.getAttribute("role")).toEqual("status");
     expect(error?.getAttribute("style")).toContain("display:none");
@@ -54,7 +60,7 @@ describe("PostcodeSearch on initial render with user configured props", async ()
     await window.happyDOM.whenAsyncComplete();
 
     const header = getShadowRootEl("postcode-search", "h1");
-    expect(header).toBeDefined;
+    expect(header).toBeTruthy;
     expect(header?.className).toContain("govuk-label-wrapper");
     expect(header?.innerHTML).toContain("label");
   });
@@ -65,12 +71,11 @@ describe("PostcodeSearch on initial render with user configured props", async ()
 
     await window.happyDOM.whenAsyncComplete();
 
-    const hintDiv =
+    const hint =
       getShadowRoot("postcode-search")?.getElementById("postcode-hint");
-    expect(hintDiv?.className).toContain("govuk-hint");
-    expect(hintDiv?.innerHTML).toContain(
-      "Enter a UK postcode, not a US zip code"
-    );
+    expect(hint).toBeTruthy;
+    expect(hint?.className).toContain("govuk-hint");
+    expect(hint?.innerHTML).toContain("Enter a UK postcode, not a US zip code");
 
     const input = getShadowRootEl("postcode-search", "input");
     expect(input?.getAttribute("aria-describedby")).toContain("postcode-hint");
@@ -95,7 +100,7 @@ describe("PostcodeSearch with input change", async () => {
     const error = getShadowRoot("postcode-search")?.getElementById(
       "postcode-error-vitest"
     );
-    expect(error).toBeDefined();
+    expect(error).toBeTruthy;
     expect(error?.getAttribute("style")).toContain("display:none");
 
     // focus & blur

--- a/src/components/postcode-search/main.test.ts
+++ b/src/components/postcode-search/main.test.ts
@@ -17,9 +17,12 @@ describe("PostcodeSearch on initial render with default props", async () => {
     await window.happyDOM.whenAsyncComplete();
   }, 1000);
 
-  it("should render a custom element", () => {
-    const input = getShadowRoot("postcode-search");
+  it("should render a custom element with a shadow root", () => {
+    const input = document.body.querySelector("postcode-search");
     expect(input).toBeTruthy;
+
+    const inputShadowRoot = getShadowRoot("postcode-search");
+    expect(inputShadowRoot).toBeTruthy;
   });
 
   it("should be keyboard navigable", () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { defineConfig } from "vite";
 import path from "path";
 import litcss from 'rollup-plugin-postcss-lit';
@@ -25,6 +26,7 @@ export default defineConfig({
       enforce: 'post'
     }
   ],
+  // https://vitest.dev/config/#options
   test: {
     globals: true,
     environment: 'happy-dom',


### PR DESCRIPTION
recent dependency upgrades seem to have cleared up the previous openlayers type error that was effecting map unit tests :tada: 

additionally updated all unit tests to use `toBeTruthy` rather than `toBeDefined` as that would still pass for null elements