### PR TITLE
fix: Ensure snap points always load

### DIFF
--- a/.github/workflows/pnpm-test.yml
+++ b/.github/workflows/pnpm-test.yml
@@ -26,3 +26,4 @@ jobs:
       - run: pnpm test
         env:
           VITE_APP_OS_PLACES_API_KEY: ${{ secrets.OS_API_KEY }}
+          VITE_APP_OS_VECTOR_TILES_API_KEY: ${{ secrets.OS_API_KEY }}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "ol-mapbox-style": "^9.0.0",
     "postcode": "^5.1.0",
     "proj4": "^2.8.0",
-    "rambda": "^7.0.1"
+    "rambda": "^7.0.1",
+    "wait-for-expect": "^3.0.2"
   },
   "devDependencies": {
     "@glorious/pitsby": "^1.30.16",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "ol-mapbox-style": "^9.0.0",
     "postcode": "^5.1.0",
     "proj4": "^2.8.0",
-    "rambda": "^7.0.1",
-    "wait-for-expect": "^3.0.2"
+    "rambda": "^7.0.1"
   },
   "devDependencies": {
     "@glorious/pitsby": "^1.30.16",
@@ -52,7 +51,8 @@
     "sass": "^1.44.0",
     "typescript": "^4.3.5",
     "vite": "^3.0.4",
-    "vitest": "0.20.3"
+    "vitest": "0.20.3",
+    "wait-for-expect": "^3.0.2"
   },
   "engines": {
     "node": "^16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,6 @@ dependencies:
   postcode: 5.1.0
   proj4: 2.8.0
   rambda: 7.0.3
-  wait-for-expect: 3.0.2
 
 devDependencies:
   '@glorious/pitsby': 1.30.16_angular@1.8.3
@@ -55,6 +54,7 @@ devDependencies:
   typescript: 4.3.5
   vite: 3.0.4_sass@1.44.0+stylus@0.58.1
   vitest: 0.20.3_w2npxtxmzs4b3q3jlg4zl7d3g4
+  wait-for-expect: 3.0.2
 
 packages:
 
@@ -5940,7 +5940,7 @@ packages:
 
   /wait-for-expect/3.0.2:
     resolution: {integrity: sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==}
-    dev: false
+    dev: true
 
   /watchpack/2.4.0:
     resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,7 @@ specifiers:
   typescript: ^4.3.5
   vite: ^3.0.4
   vitest: 0.20.3
+  wait-for-expect: ^3.0.2
 
 dependencies:
   '@turf/union': 6.5.0
@@ -36,6 +37,7 @@ dependencies:
   postcode: 5.1.0
   proj4: 2.8.0
   rambda: 7.0.3
+  wait-for-expect: 3.0.2
 
 devDependencies:
   '@glorious/pitsby': 1.30.16_angular@1.8.3
@@ -5935,6 +5937,10 @@ packages:
       - supports-color
       - terser
     dev: true
+
+  /wait-for-expect/3.0.2:
+    resolution: {integrity: sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==}
+    dev: false
 
   /watchpack/2.4.0:
     resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}

--- a/src/components/my-map/main.test.ts
+++ b/src/components/my-map/main.test.ts
@@ -1,20 +1,36 @@
 import type { IWindow } from "happy-dom";
-import { beforeEach, describe, it, expect } from "vitest";
+import { beforeEach, describe, it, expect, MockInstance } from "vitest";
+import Map from "ol/Map";
+import { Feature } from "ol";
+import Point from "ol/geom/Point";
+import VectorSource from "ol/source/Vector";
+import waitForExpect from "wait-for-expect";
 
 import { getShadowRoot } from "../../test-utils";
-
+import * as snapping from "./snapping";
 import "./index";
 
 declare global {
   interface Window extends IWindow {}
 }
 
-describe("MyMap on initial render with OSM basemap", async () => {
-  beforeEach(async () => {
-    document.body.innerHTML = '<my-map id="map-vitest" disableVectorTiles />';
+const setupMap = async (mapElement: any) => {
+  document.body.innerHTML = mapElement;
+  await window.happyDOM.whenAsyncComplete();
+  window.olMap?.dispatchEvent("loadend");
+};
 
-    await window.happyDOM.whenAsyncComplete();
-  }, 2500);
+test("olMap is added to the global window for tests", async () => {
+  await setupMap(`<my-map id="map-vitest" disableVectorTiles />`);
+  expect(window.olMap).not.toBeUndefined();
+  expect(window.olMap).toBeInstanceOf(Map);
+});
+
+describe("MyMap on initial render with OSM basemap", async () => {
+  beforeEach(
+    () => setupMap('<my-map id="map-vitest" disableVectorTiles />'),
+    2500
+  );
 
   it("should render a custom element with a shadow root", () => {
     const map = document.body.querySelector("my-map");
@@ -28,5 +44,91 @@ describe("MyMap on initial render with OSM basemap", async () => {
     const map = getShadowRoot("my-map")?.getElementById("map-vitest");
     expect(map).toBeTruthy;
     expect(map?.getAttribute("tabindex")).toEqual("0");
+  });
+});
+
+describe("Snap points loading behaviour", () => {
+  const ZOOM_WITHIN_RANGE = 25;
+  const ZOOM_OUTWITH_RANGE = 15;
+
+  const getSnapSpy: MockInstance = vi.spyOn(
+    snapping,
+    "getSnapPointsFromVectorTiles"
+  );
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("should not load snap points if the initial zoom is not within range", async () => {
+    await setupMap(`<my-map 
+      id="map-vitest" 
+      zoom=${ZOOM_OUTWITH_RANGE} 
+      drawMode 
+      osVectorTileApiKey=${process.env.VITE_APP_OS_VECTOR_TILES_API_KEY}
+    />`);
+    const pointLayer = window.olMap
+      ?.getAllLayers()
+      .find((layer) => layer.get("name") === "pointLayer");
+    expect(pointLayer).toBeDefined();
+    const source = pointLayer?.getSource() as VectorSource;
+    expect(source.getFeatures()?.length).toEqual(0);
+    expect(getSnapSpy).not.toHaveBeenCalled();
+  });
+
+  it("should load snap points if the initial zoom is within range", async () => {
+    await setupMap(`<my-map 
+      id="map-vitest" 
+      zoom=${ZOOM_WITHIN_RANGE} 
+      drawMode 
+      osVectorTileApiKey=${process.env.VITE_APP_OS_VECTOR_TILES_API_KEY}
+    />`);
+    expect(getSnapSpy).toHaveBeenCalled();
+  });
+
+  it("should load snap points on zoom into correct range", async () => {
+    await setupMap(`<my-map 
+      id="map-vitest" 
+      zoom=${ZOOM_OUTWITH_RANGE} 
+      drawMode 
+      osVectorTileApiKey=${process.env.VITE_APP_OS_VECTOR_TILES_API_KEY}
+    />`);
+    window.olMap?.getView().setZoom(ZOOM_WITHIN_RANGE);
+    window.olMap?.dispatchEvent("loadend");
+    expect(getSnapSpy).toHaveBeenCalled();
+  });
+
+  it("should clear snap points on zoom out of range", async () => {
+    // Setup map and add a mock snap point
+    await setupMap(`<my-map 
+      id="map-vitest" 
+      zoom=${ZOOM_WITHIN_RANGE}
+      drawMode 
+      osVectorTileApiKey=${process.env.VITE_APP_OS_VECTOR_TILES_API_KEY}
+    />`);
+    const pointLayer = window.olMap
+      ?.getAllLayers()
+      .find((layer) => layer.get("name") === "pointLayer");
+    const source = pointLayer?.getSource() as VectorSource;
+    const mockSnapPoint = new Feature(new Point([1, 1]));
+    source?.addFeature(mockSnapPoint);
+    expect(source.getFeatures()?.length).toEqual(1);
+
+    // Zoom out to clear the point layer
+    window.olMap?.getView().setZoom(ZOOM_OUTWITH_RANGE);
+    window.olMap?.dispatchEvent("loadend");
+    expect(getSnapSpy).toHaveBeenCalledOnce();
+    expect(source.getFeatures()?.length).toEqual(0);
+  });
+
+  it("refetches snap points on a pan", async () => {
+    await setupMap(`<my-map 
+      id="map-vitest" 
+      zoom=${ZOOM_WITHIN_RANGE}
+      drawMode 
+      osVectorTileApiKey=${process.env.VITE_APP_OS_VECTOR_TILES_API_KEY}
+    />`);
+    expect(getSnapSpy).toHaveBeenCalledTimes(1);
+    window.olMap?.dispatchEvent("moveend");
+    await waitForExpect(() => expect(getSnapSpy).toHaveBeenCalledTimes(2));
   });
 });

--- a/src/components/my-map/main.test.ts
+++ b/src/components/my-map/main.test.ts
@@ -66,11 +66,11 @@ describe("Snap points loading behaviour", () => {
       drawMode 
       osVectorTileApiKey=${process.env.VITE_APP_OS_VECTOR_TILES_API_KEY}
     />`);
-    const pointLayer = window.olMap
+    const pointsLayer = window.olMap
       ?.getAllLayers()
-      .find((layer) => layer.get("name") === "pointLayer");
-    expect(pointLayer).toBeDefined();
-    const source = pointLayer?.getSource() as VectorSource;
+      .find((layer) => layer.get("name") === "pointsLayer");
+    expect(pointsLayer).toBeDefined();
+    const source = pointsLayer?.getSource() as VectorSource;
     expect(source.getFeatures()?.length).toEqual(0);
     expect(getSnapSpy).not.toHaveBeenCalled();
   });
@@ -105,10 +105,10 @@ describe("Snap points loading behaviour", () => {
       drawMode 
       osVectorTileApiKey=${process.env.VITE_APP_OS_VECTOR_TILES_API_KEY}
     />`);
-    const pointLayer = window.olMap
+    const pointsLayer = window.olMap
       ?.getAllLayers()
-      .find((layer) => layer.get("name") === "pointLayer");
-    const source = pointLayer?.getSource() as VectorSource;
+      .find((layer) => layer.get("name") === "pointsLayer");
+    const source = pointsLayer?.getSource() as VectorSource;
     const mockSnapPoint = new Feature(new Point([1, 1]));
     source?.addFeature(mockSnapPoint);
     expect(source.getFeatures()?.length).toEqual(1);

--- a/src/components/my-map/main.test.ts
+++ b/src/components/my-map/main.test.ts
@@ -22,7 +22,7 @@ const setupMap = async (mapElement: any) => {
 
 test("olMap is added to the global window for tests", async () => {
   await setupMap(`<my-map id="map-vitest" disableVectorTiles />`);
-  expect(window.olMap).not.toBeUndefined();
+  expect(window.olMap).toBeTruthy();
   expect(window.olMap).toBeInstanceOf(Map);
 });
 
@@ -82,7 +82,7 @@ describe("Snap points loading behaviour", () => {
       drawMode 
       osVectorTileApiKey=${process.env.VITE_APP_OS_VECTOR_TILES_API_KEY}
     />`);
-    expect(getSnapSpy).toHaveBeenCalled();
+    expect(getSnapSpy).toHaveBeenCalledOnce();
   });
 
   it("should load snap points on zoom into correct range", async () => {
@@ -94,7 +94,7 @@ describe("Snap points loading behaviour", () => {
     />`);
     window.olMap?.getView().setZoom(ZOOM_WITHIN_RANGE);
     window.olMap?.dispatchEvent("loadend");
-    expect(getSnapSpy).toHaveBeenCalled();
+    expect(getSnapSpy).toHaveBeenCalledOnce();
   });
 
   it("should clear snap points on zoom out of range", async () => {

--- a/src/components/my-map/snapping.ts
+++ b/src/components/my-map/snapping.ts
@@ -15,7 +15,7 @@ export const pointsSource = new VectorSource({
 export const pointsLayer = new VectorLayer({
   source: pointsSource,
   properties: {
-    name: "pointLayer",
+    name: "pointsLayer",
   },
   style: new Style({
     image: new CircleStyle({

--- a/src/components/my-map/snapping.ts
+++ b/src/components/my-map/snapping.ts
@@ -14,6 +14,9 @@ export const pointsSource = new VectorSource({
 
 export const pointsLayer = new VectorLayer({
   source: pointsSource,
+  properties: {
+    name: "pointLayer",
+  },
   style: new Style({
     image: new CircleStyle({
       radius: 3,


### PR DESCRIPTION
Addresses https://trello.com/c/NZrvqg7d/2055-get-snap-points-on-map-to-always-load

Currently, points are automatically generated on the assumption that vector tiles will be loaded. On slower connections, this means that snap points either do not display or do not fully display. This can be mocked in the browser by throttling your connection speed.

This PR fixes this by waiting for the map `loadend` event before triggering the generation of the snap points. Originally I was listening for the vector source's `tileloadend` event but this fires for each tile load and then regenerates snap points which I imagine is both computationally expensive and could lead to inconsistent results (e.g. all snap points loading in one tile at a time).

Also - some basic OL tests! Couldn't quite get around a few event dispatch issues so I'm manually calling them currently. This would be great to try and remove - possibly something to tackle when/if we add Cypress to the stack.