### PR TITLE
build: update vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "sass": "^1.44.0",
     "typescript": "^4.3.5",
     "vite": "^3.0.4",
-    "vitest": "0.20.3",
+    "vitest": "0.23.2",
     "wait-for-expect": "^3.0.2"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ specifiers:
   sass: ^1.44.0
   typescript: ^4.3.5
   vite: ^3.0.4
-  vitest: 0.20.3
+  vitest: 0.23.2
   wait-for-expect: ^3.0.2
 
 dependencies:
@@ -53,7 +53,7 @@ devDependencies:
   sass: 1.44.0
   typescript: 4.3.5
   vite: 3.0.4_sass@1.44.0+stylus@0.58.1
-  vitest: 0.20.3_5t5iw3uupykq36nc3lm2ppikjq
+  vitest: 0.23.2_5t5iw3uupykq36nc3lm2ppikjq
   wait-for-expect: 3.0.2
 
 packages:
@@ -5536,6 +5536,12 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /strip-literal/0.4.0:
+    resolution: {integrity: sha512-ql/sBDoJOybTKSIOWrrh8kgUEMjXMwRAkZTD0EwiwxQH/6tTPkZvMIEjp0CRlpi6V5FMiJyvxeRkEi1KrGISoA==}
+    dependencies:
+      acorn: 8.8.0
+    dev: true
+
   /style-loader/3.3.1_webpack@5.74.0:
     resolution: {integrity: sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==}
     engines: {node: '>= 12.13.0'}
@@ -5708,13 +5714,17 @@ packages:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
     dev: true
 
-  /tinypool/0.2.4:
-    resolution: {integrity: sha512-Vs3rhkUH6Qq1t5bqtb816oT+HeJTXfwt2cbPH17sWHIYKTotQIFPk3tf2fgqRrVyMDVOc1EnPgzIxfIulXVzwQ==}
+  /tinybench/2.1.5:
+    resolution: {integrity: sha512-ak+PZZEuH3mw6CCFOgf5S90YH0MARnZNhxjhjguAmoJimEMAJuNip/rJRd6/wyylHItomVpKTzZk9zrhTrQCoQ==}
+    dev: true
+
+  /tinypool/0.3.0:
+    resolution: {integrity: sha512-NX5KeqHOBZU6Bc0xj9Vr5Szbb1j8tUHIeD18s41aDJaPeC5QTdEhK0SpdpUrZlj2nv5cctNcSjaKNanXlfcVEQ==}
     engines: {node: '>=14.0.0'}
     dev: true
 
-  /tinyspy/1.0.0:
-    resolution: {integrity: sha512-FI5B2QdODQYDRjfuLF+OrJ8bjWRMCXokQPcwKm0W3IzcbUmBNv536cQc7eXGoAuXphZwgx1DFbqImwzz08Fnhw==}
+  /tinyspy/1.0.2:
+    resolution: {integrity: sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -5894,15 +5904,14 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vitest/0.20.3_5t5iw3uupykq36nc3lm2ppikjq:
-    resolution: {integrity: sha512-cXMjTbZxBBUUuIF3PUzEGPLJWtIMeURBDXVxckSHpk7xss4JxkiiWh5cnIlfGyfJne2Ii3QpbiRuFL5dMJtljw==}
+  /vitest/0.23.2_5t5iw3uupykq36nc3lm2ppikjq:
+    resolution: {integrity: sha512-kTBKp3ROPDkYC+x2zWt4znkDtnT08W1FQ6ngRFuqxpBGNuNVS+eWZKfffr8y2JGvEzZ9EzMAOcNaiqMj/FZqMw==}
     engines: {node: '>=v14.16.0'}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@vitest/browser': '*'
       '@vitest/ui': '*'
-      c8: '*'
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -5911,8 +5920,6 @@ packages:
       '@vitest/browser':
         optional: true
       '@vitest/ui':
-        optional: true
-      c8:
         optional: true
       happy-dom:
         optional: true
@@ -5927,8 +5934,10 @@ packages:
       debug: 4.3.4
       happy-dom: 6.0.4
       local-pkg: 0.4.2
-      tinypool: 0.2.4
-      tinyspy: 1.0.0
+      strip-literal: 0.4.0
+      tinybench: 2.1.5
+      tinypool: 0.3.0
+      tinyspy: 1.0.2
       vite: 3.0.4_sass@1.44.0+stylus@0.58.1
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
replaces #185 with newest versions

[release notes](https://github.com/vitest-dev/vitest/releases) for v0.23.1 specifically mentions a bug fix: "don't hang when running vitest" :crossed_fingers: