### PR TITLE
feat: add `resetControlImage` prop for testing custom icons

### DIFF
--- a/src/components/my-map/controls.ts
+++ b/src/components/my-map/controls.ts
@@ -1,6 +1,9 @@
-import "ol/ol.css";
 import { Control, ScaleLine } from "ol/control";
+import "ol/ol.css";
+import eraseIcon from "./icons/erase.svg";
 import northArrowIcon from "./icons/north-arrow-n.svg";
+import resetIcon from "./icons/reset.svg";
+import trashCanIcon from "./icons/trash-can.svg";
 
 export function scaleControl(useScaleBarStyle: boolean) {
   return new ScaleLine({
@@ -20,6 +23,35 @@ export function northArrowControl() {
   const element = document.createElement("div");
   element.className = "north-arrow-control ol-unselectable ol-control";
   element.appendChild(image);
+
+  return new Control({ element: element });
+}
+
+export function resetControl(listener: any, icon: string) {
+  const button = document.createElement("button");
+  button.title = "Reset map view";
+
+  if (icon === "unicode") {
+    button.innerHTML = "↻";
+  } else {
+    const propToSVGLookup: any = {
+      reset: resetIcon,
+      trash: trashCanIcon,
+      erase: eraseIcon,
+    };
+    const image = document.createElement("img");
+    image.className = "reset-icon";
+    image.src = propToSVGLookup[icon];
+    button.appendChild(image);
+  }
+
+  // this is an internal event listener, so doesn't need to be removed later
+  // ref https://lit.dev/docs/components/lifecycle/#disconnectedcallback
+  button.addEventListener("click", listener, false);
+
+  const element = document.createElement("div");
+  element.className = "reset-control ol-unselectable ol-control";
+  element.appendChild(button);
 
   return new Control({ element: element });
 }

--- a/src/components/my-map/icons/README.md
+++ b/src/components/my-map/icons/README.md
@@ -1,1 +1,1 @@
-Icons are sourced from [Font-GIS](https://viglino.github.io/font-gis/?fg=arrow-o)
+Icons are sourced from [Font-GIS](https://viglino.github.io/font-gis/?fg=arrow-o) and [Carbon Design System](https://carbondesignsystem.com/guidelines/icons/library)

--- a/src/components/my-map/icons/erase.svg
+++ b/src/components/my-map/icons/erase.svg
@@ -1,0 +1,10 @@
+<svg id="icon"
+  xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <style>.cls-1{fill:none;}</style>
+  </defs>
+  <title>erase</title>
+  <rect fill="white" x="7" y="27" width="23" height="2" />
+  <path fill="white" d="M27.38,10.51,19.45,2.59a2,2,0,0,0-2.83,0l-14,14a2,2,0,0,0,0,2.83L7.13,24h9.59L27.38,13.34A2,2,0,0,0,27.38,10.51ZM15.89,22H8L4,18l6.31-6.31,7.93,7.92Zm3.76-3.76-7.92-7.93L18,4,26,11.93Z" transform="translate(0 0)"/>
+  <rect fill="white" id="_Transparent_Rectangle_" data-name="&lt;Transparent Rectangle&gt;" class="cls-1" width="32" height="32" />
+</svg>

--- a/src/components/my-map/icons/reset.svg
+++ b/src/components/my-map/icons/reset.svg
@@ -1,0 +1,9 @@
+<svg id="icon"
+  xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <style>.cls-1{fill:none;}</style>
+  </defs>
+  <title>reset</title>
+  <path fill="white" d="M18,28A12,12,0,1,0,6,16v6.2L2.4,18.6,1,20l6,6,6-6-1.4-1.4L8,22.2V16H8A10,10,0,1,1,18,26Z"/>
+  <rect fill="white" id="_Transparent_Rectangle_" data-name="&lt;Transparent Rectangle&gt;" class="cls-1" width="32" height="32"/>
+</svg>

--- a/src/components/my-map/icons/trash-can.svg
+++ b/src/components/my-map/icons/trash-can.svg
@@ -1,0 +1,12 @@
+<svg id="icon"
+  xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <style>.cls-1{fill:none;}</style>
+  </defs>
+  <title>trash-can</title>
+  <rect fill="white" x="12" y="12" width="2" height="12"/>
+  <rect fill="white" x="18" y="12" width="2" height="12"/>
+  <path fill="white" d="M4,6V8H6V28a2,2,0,0,0,2,2H24a2,2,0,0,0,2-2V8h2V6ZM8,28V8H24V28Z"/>
+  <rect fill="white" x="12" y="2" width="8" height="2"/>
+  <rect fill="white" id="_Transparent_Rectangle_" data-name="&lt;Transparent Rectangle&gt;" class="cls-1" width="32" height="32"/>
+</svg>

--- a/src/components/my-map/styles.scss
+++ b/src/components/my-map/styles.scss
@@ -30,6 +30,10 @@
   top: 114px;
   left: 0.5em;
 }
+.reset-control img {
+  width: 30px;
+  height: auto;
+}
 .north-arrow-control img {
   width: 44px;
   height: auto;


### PR DESCRIPTION
adds `resetControlImage` ENUM property to specify a custom icon to show on the reset control button. Defaults to our current unicode arrow.

This is a bit of a tricky UAT request because we need to make a whole release. Once an icon is decided on, an ENUM property will likely be unnecessary and we can clean this up. If we decide to go with one of these new options, it may also be worth considering to source all icons from Carbon rather than mixing libraries? 

| `resetControlImage` value  | display   |
|---|---|
| `unicode` (default) | ![Screenshot from 2022-10-14 10-11-37](https://user-images.githubusercontent.com/5132349/195797797-28599348-4f22-41d5-92d1-463e2d5ec865.png) |
| `reset`  |  ![Screenshot from 2022-10-14 10-09-53](https://user-images.githubusercontent.com/5132349/195797937-4ee68df0-ebe9-4955-97fa-aacaa307b887.png) |
|  `trash` | ![Screenshot from 2022-10-14 10-10-16](https://user-images.githubusercontent.com/5132349/195798208-7c6f9f93-39da-4611-bdda-485f187f51f7.png) |
| `erase` | ![Screenshot from 2022-10-14 10-10-30](https://user-images.githubusercontent.com/5132349/195798256-c97978cf-d898-49bf-8f74-fda2127129a7.png) |
