### PR TITLE
chore: cleanup styling of default scale line

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
     <div style="display:flex;flex-direction:column;">
       <h1 style="color:red;font-family:Inter,Helvetica,sans-serif;font-size:16px;">*** This is a testing sandbox - these components are unaware of each other! ***</h1>
       <div style="margin-bottom:1em">
-        <my-map zoom="20" maxZoom="23" drawMode drawPointer="dot" id="example-map" />
+        <my-map zoom="20" maxZoom="23" drawMode drawPointer="dot" id="example-map" showScale />
       </div>
       <div style="margin-bottom:1em">
         <postcode-search hintText="Optional hint text shows up here" id="example-postcode" />

--- a/src/components/my-map/styles.scss
+++ b/src/components/my-map/styles.scss
@@ -26,6 +26,16 @@
 .ol-control button:hover {
   background-color: rgba(44, 44, 44, 0.85) !important;
 }
+.ol-scale-line {
+  background-color: transparent;
+}
+.ol-scale-line-inner {
+  border: 0.2em solid #2c2c2c;
+  border-top: none;
+  color: #2c2c2c;
+  font-size: 1em;
+  font-family: inherit;
+}
 .reset-control {
   top: 114px;
   left: 0.5em;


### PR DESCRIPTION
Override the default openlayers translucent blue with a cleaner style that better fits our Gov UK-esque styles
![Screenshot from 2022-12-07 13-00-18](https://user-images.githubusercontent.com/5132349/206174675-94b44674-10bc-42a8-bdb3-ca410cc4c2e6.png)
