### PR TITLE
feat: enable drawing single point

### DIFF
--- a/src/components/my-map/drawing.ts
+++ b/src/components/my-map/drawing.ts
@@ -2,28 +2,15 @@ import { MultiPoint, Polygon } from "ol/geom";
 import { Draw, Modify, Snap } from "ol/interaction";
 import { Vector as VectorLayer } from "ol/layer";
 import { Vector as VectorSource } from "ol/source";
-import { Fill, RegularShape, Stroke, Style } from "ol/style";
+import { Circle, Fill, RegularShape, Stroke, Style } from "ol/style";
 import CircleStyle from "ol/style/Circle";
+import { StyleLike } from "ol/style/Style";
 import { pointsSource } from "./snapping";
 
+export type DrawTypeEnum = "Polygon" | "Point"; // ref https://openlayers.org/en/latest/apidoc/module-ol_geom_Geometry.html#~Type
 export type DrawPointerEnum = "crosshair" | "dot";
 
-const redLineBase = {
-  color: "#ff0000",
-  width: 3,
-};
-
-const redLineStroke = new Stroke(redLineBase);
-
-const redDashedStroke = new Stroke({
-  ...redLineBase,
-  lineDash: [2, 8],
-});
-
-const redLineFill = new Fill({
-  color: "rgba(255, 0, 0, 0.1)",
-});
-
+// drawPointer styles
 const crosshair = new RegularShape({
   stroke: new Stroke({
     color: "red",
@@ -41,7 +28,24 @@ const dot = new CircleStyle({
   }),
 });
 
-const drawingVertices = new Style({
+// feature style: red-line site boundary
+const redLineBase = {
+  color: "#ff0000",
+  width: 3,
+};
+
+const redLineStroke = new Stroke(redLineBase);
+
+const redDashedStroke = new Stroke({
+  ...redLineBase,
+  lineDash: [2, 8],
+});
+
+const redLineFill = new Fill({
+  color: "rgba(255, 0, 0, 0.1)",
+});
+
+const polygonVertices = new Style({
   image: new RegularShape({
     fill: new Fill({
       color: "#fff",
@@ -66,28 +70,66 @@ const drawingVertices = new Style({
   },
 });
 
+const boundaryLayerStyle: StyleLike = [
+  new Style({
+    fill: redLineFill,
+    stroke: redLineStroke,
+  }),
+  polygonVertices,
+];
+
+function configureBoundaryDrawStyle(pointerStyle: DrawPointerEnum) {
+  return new Style({
+    stroke: redDashedStroke,
+    fill: redLineFill,
+    image: pointerStyle === "crosshair" ? crosshair : dot,
+  });
+}
+
+// feature style: single point
+function configurePointLayerStyle(pointColor: string) {
+  return new Style({
+    image: new Circle({
+      radius: 9,
+      fill: new Fill({ color: pointColor }),
+    }),
+  });
+}
+
+function configurePointDrawStyle(pointColor: string) {
+  return new Style({
+    fill: new Fill({ color: pointColor }),
+  });
+}
+
 export const drawingSource = new VectorSource();
 
-export const drawingLayer = new VectorLayer({
-  source: drawingSource,
-  style: [
-    new Style({
-      fill: redLineFill,
-      stroke: redLineStroke,
-    }),
-    drawingVertices,
-  ],
-});
+export function configureDrawingLayer(
+  drawType: DrawTypeEnum,
+  pointColor: string
+) {
+  return new VectorLayer({
+    source: drawingSource,
+    style:
+      drawType === "Polygon"
+        ? boundaryLayerStyle
+        : configurePointLayerStyle(pointColor),
+  });
+}
 
-export function configureDraw(pointerStyle: DrawPointerEnum) {
+// configure the key openlayers interactions
+export function configureDraw(
+  drawType: DrawTypeEnum,
+  pointerStyle: DrawPointerEnum,
+  pointColor: string
+) {
   return new Draw({
     source: drawingSource,
-    type: "Polygon",
-    style: new Style({
-      stroke: redDashedStroke,
-      fill: redLineFill,
-      image: pointerStyle === "crosshair" ? crosshair : dot,
-    }),
+    type: drawType,
+    style:
+      drawType === "Polygon"
+        ? configureBoundaryDrawStyle(pointerStyle)
+        : configurePointDrawStyle(pointColor),
   });
 }
 


### PR DESCRIPTION
Context:
- `drawMode` previously assumed the geometry type "Polygon" because we've only used it for drawing site boundaries
- now, we want to support an additional drawing mode where you can plot a single point on the map to denote a "new address"
- i think it's safe to assume that we don't need to support drawing a polygon and point _at the same time on a single map_, so these functionalities can share a source

Changes:
- adds optional prop `drawType` to specify "Polygon" (default) or "Point" when using `drawMode`
- adds optional prop `drawPointColor` to specify the color of the feature
- only displays snap points when drawing a "Polygon"
- only dispatches the `areaChange` event when drawing a "Polygon"
- otherwise "Point" drawing carries the same assumptions as "Polygon": limit to 1 feature, ability to modify after plotted, can be "reset", will dispatch a `geojsonChange` event

To test: 
```html
<my-map drawMode drawType="Point" />
```

Future scope: 
- clean up point styling, make more customizable? 
- dispatch a point-specific change event with the coordinates in _both_ EPSG:4326 & BNG ? for now, planx will just read from the geojson but i can imagine in the future we may want to be better aligned to Ordnance Survey format for existing addresses