### PR TITLE
fix: Resolve shadow class fields warning

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "rootDir": "./src",
     "skipLibCheck": true,
     "strict": true,
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
+    "useDefineForClassFields": false
   },
   "include": ["src/**/*.ts", "types/*.d.ts"],
   "exclude": ["src/components/*.doc.js", "src/components/docs/*.doc.js"]


### PR DESCRIPTION
A warning is being thrown in the dev sandbox console, pointing to the following docs -  https://lit.dev/docs/components/properties/\#avoiding-issues-with-class-fields

Possibly something picked up after the most recent updates?

<img width="568" alt="image" src="https://user-images.githubusercontent.com/20502206/207543390-171cdd5e-bb34-4153-9114-44785b6b1245.png">
