### PR TITLE
feat: Hide OS API key by allowing proxy endpoint

### DIFF
--- a/docs/how-to-use-a-proxy.md
+++ b/docs/how-to-use-a-proxy.md
@@ -1,0 +1,97 @@
+# How to: Use a MyMap & AddressAutocomplete with a proxy
+
+## Context
+Both `MyMap` and `AddressAutocomplete` can call the Ordnance Survey API directly, or via a proxy. 
+
+Calling the API directly may be suitable for internal use, where exposure of API keys is not a concern, whilst calling a proxy may be more suitable for public use.
+
+A proxy endpoint can be supplied via the `osProxyEndpoint` property on these components.
+
+Proxies are required to complete the following actions in order to work successfully - 
+
+- Append a valid OS API key as a search parameter to incoming requests
+- Modify outgoing response with suitable CORS / CORP headers to allow the originating site access to the returned assets
+
+## Diagram
+```mermaid
+sequenceDiagram
+    autonumber
+    participant WC as Web Component
+    participant P as Proxy
+    participant OS as Ordnance Survey API
+
+    WC ->>+ P: Request
+    P -->> P: Validate Request
+    P ->>+ OS: Request + API key
+    OS ->>- P: Response
+    P ->>- WC: Response + CORP/CORS headers
+```
+
+## Examples
+Please see the sample code below for how a proxy could be implemented - 
+
+### Express
+Below is an annotated example of a simple proxy using [Express](https://github.com/expressjs/express) & [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware).
+
+**index.js**
+```js
+import express from "express";
+import { useOrdnanceSurveyProxy } from "proxy";
+
+const app = express()
+const port = 3000
+
+app.use('/proxy/ordnance-survey', useOrdnanceSurveyProxy)
+
+app.listen(port)
+```
+
+**proxy.js**
+```js
+import { createProxyMiddleware } from "http-proxy-middleware";
+
+const OS_DOMAIN = "https://api.os.uk";
+
+export const useOrdnanceSurveyProxy = async (req, res, next) => {
+  if (!isValid(req)) return next({
+    status: 401,
+    message: "Unauthorised"
+  })
+
+  return createProxyMiddleware({
+    target: OS_DOMAIN,
+    changeOrigin: true,
+    onProxyRes: (proxyRes) => setCORPHeaders(proxyRes),
+    pathRewrite: (fullPath, req) => appendAPIKey(fullPath, req)
+    onError: (_err, _req, res) => {
+      res.json({
+        status: 500,
+        message: "Something went wrong",
+      });
+    },
+  })(req, res, next);
+};
+
+const isValid = (req) => {
+  // Your validation logic here, for example checking req.header.referer against an allowlist of domains
+}
+
+// Ensure that returned tiles can be embedded cross-site
+// May not be required if "same-site" policy works for your setup
+const setCORPHeaders = (proxyRes: IncomingMessage): void => {
+  proxyRes.headers["Cross-Origin-Resource-Policy"] = "cross-origin"
+}
+
+export const appendAPIKey = (fullPath, req) => {
+  const [path, params] = fullPath.split("?");
+  // Append API key
+  const updatedParams = new URLSearchParams(params);
+  updatedParams.set("key", process.env.ORDNANCE_SURVEY_API_KEY);
+  // Remove our API baseUrl (/proxy/ordnance-survey)
+  const updatedPath = path.replace(req.baseUrl, "");
+  // Construct and return rewritten path
+  const resultPath = [updatedPath, updatedParams.toString()].join("?");
+  return resultPath;
+};
+```
+> A working and more fleshed out example (in TypeScript) can be seen [here in the PlanX API](https://github.com/theopensystemslab/planx-new/blob/production/api.planx.uk/proxy/ordnanceSurvey.ts).

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
     <div style="display:flex;flex-direction:column;">
       <h1 style="color:red;font-family:Inter,Helvetica,sans-serif;font-size:16px;">*** This is a testing sandbox - these components are unaware of each other! ***</h1>
       <div style="margin-bottom:1em">
-        <my-map zoom="20" maxZoom="23" drawMode drawPointer="dot" id="example-map" showScale disableVectorTiles osProxyEndpoint="http://api.1334.planx.pizza/proxy/ordnance-survey" />
+        <my-map zoom="20" maxZoom="23" drawMode drawPointer="dot" id="example-map" showScale disableVectorTiles osProxyEndpoint="https://api.editor.planx.dev/proxy/ordnance-survey" />
       </div>
       <div style="margin-bottom:1em">
         <postcode-search hintText="Optional hint text shows up here" id="example-postcode" />

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
     <div style="display:flex;flex-direction:column;">
       <h1 style="color:red;font-family:Inter,Helvetica,sans-serif;font-size:16px;">*** This is a testing sandbox - these components are unaware of each other! ***</h1>
       <div style="margin-bottom:1em">
-        <my-map zoom="20" maxZoom="23" drawMode drawPointer="dot" id="example-map" showScale />
+        <my-map zoom="20" maxZoom="23" drawMode drawPointer="dot" id="example-map" showScale disableVectorTiles osProxyEndpoint="http://api.1334.planx.pizza/proxy/ordnance-survey" />
       </div>
       <div style="margin-bottom:1em">
         <postcode-search hintText="Optional hint text shows up here" id="example-postcode" />

--- a/src/components/address-autocomplete/address-autocomplete.doc.js
+++ b/src/components/address-autocomplete/address-autocomplete.doc.js
@@ -1,7 +1,7 @@
 module.exports = {
   name: "AddressAutocomplete",
   description:
-    "AddressAutocomplete is a Lit wrapper for the Gov.UK accessible-autocomplete component that fetches & displays addresses in a given postcode using the Ordnance Survey Places API. The Ordnance Survey API can be called directly, or via a proxy. Calling the API directly may be suitable for internal use, where exposure of API keys is not a concern, whilst calling a proxy may be more suitable for public use. Any proxy supplied via the osProxyEndpoint property must append a valid Ordnance Survey API key to all requests. For full implementation details, please see XXXX",
+    "AddressAutocomplete is a Lit wrapper for the Gov.UK accessible-autocomplete component that fetches & displays addresses in a given postcode using the Ordnance Survey Places API. The Ordnance Survey API can be called directly, or via a proxy. Calling the API directly may be suitable for internal use, where exposure of API keys is not a concern, whilst calling a proxy may be more suitable for public use. Any proxy supplied via the osProxyEndpoint property must append a valid Ordnance Survey API key to all requests. For full implementation details, please see https://github.com/theopensystemslab/map/blob/main/docs/how-to-use-a-proxy.md",
   properties: [
     {
       name: "postcode",
@@ -43,7 +43,7 @@ module.exports = {
     {
       name: "osProxyEndpoint",
       type: "String",
-      values: "https://api.1334.planx.pizza/proxy/ordnance-survey",
+      values: "https://api.planx.dev/proxy/ordnance-survey",
     },
   ],
   methods: [
@@ -95,7 +95,7 @@ module.exports = {
     {
       title: "Select an address in postcode SE19 1NT",
       description: "Standard case (via proxy)",
-      template: `<address-autocomplete postcode="SE19 1NT" osPlacesApiKey="" osProxyEndpoint="https://api.1334.planx.pizza/proxy/ordnance-survey" />`,
+      template: `<address-autocomplete postcode="SE19 1NT" osPlacesApiKey="" osProxyEndpoint="https://api.planx.dev/proxy/ordnance-survey" />`,
       controller: function (document) {
         const autocomplete = document.querySelector("address-autocomplete");
 

--- a/src/components/address-autocomplete/address-autocomplete.doc.js
+++ b/src/components/address-autocomplete/address-autocomplete.doc.js
@@ -1,7 +1,7 @@
 module.exports = {
   name: "AddressAutocomplete",
   description:
-    "AddressAutocomplete is a Lit wrapper for the Gov.UK accessible-autocomplete component that fetches & displays addresses in a given postcode using the Ordnance Survey Places API.",
+    "AddressAutocomplete is a Lit wrapper for the Gov.UK accessible-autocomplete component that fetches & displays addresses in a given postcode using the Ordnance Survey Places API. The Ordnance Survey API can be called directly, or via a proxy. Calling the API directly may be suitable for internal use, where exposure of API keys is not a concern, whilst calling a proxy may be more suitable for public use. Any proxy supplied via the osProxyEndpoint property must append a valid Ordnance Survey API key to all requests. For full implementation details, please see XXXX",
   properties: [
     {
       name: "postcode",
@@ -40,6 +40,11 @@ module.exports = {
       values: "https://osdatahub.os.uk/plans",
       required: true,
     },
+    {
+      name: "osProxyEndpoint",
+      type: "String",
+      values: "https://api.1334.planx.pizza/proxy/ordnance-survey",
+    },
   ],
   methods: [
     {
@@ -72,6 +77,25 @@ module.exports = {
       title: "Select an address in postcode SE19 1NT",
       description: "Standard case",
       template: `<address-autocomplete postcode="SE19 1NT" osPlacesApiKey=${process.env.VITE_APP_OS_PLACES_API_KEY} />`,
+      controller: function (document) {
+        const autocomplete = document.querySelector("address-autocomplete");
+
+        autocomplete.addEventListener("ready", ({ detail: data }) => {
+          console.debug("autocomplete ready", { data });
+        });
+
+        autocomplete.addEventListener(
+          "addressSelection",
+          ({ detail: address }) => {
+            console.debug({ detail: address });
+          }
+        );
+      },
+    },
+    {
+      title: "Select an address in postcode SE19 1NT",
+      description: "Standard case (via proxy)",
+      template: `<address-autocomplete postcode="SE19 1NT" osPlacesApiKey="" osProxyEndpoint="https://api.1334.planx.pizza/proxy/ordnance-survey" />`,
       controller: function (document) {
         const autocomplete = document.querySelector("address-autocomplete");
 

--- a/src/components/address-autocomplete/address-autocomplete.doc.js
+++ b/src/components/address-autocomplete/address-autocomplete.doc.js
@@ -43,7 +43,7 @@ module.exports = {
     {
       name: "osProxyEndpoint",
       type: "String",
-      values: "https://api.planx.dev/proxy/ordnance-survey",
+      values: "https://api.editor.planx.dev/proxy/ordnance-survey",
     },
   ],
   methods: [
@@ -95,7 +95,7 @@ module.exports = {
     {
       title: "Select an address in postcode SE19 1NT",
       description: "Standard case (via proxy)",
-      template: `<address-autocomplete postcode="SE19 1NT" osPlacesApiKey="" osProxyEndpoint="https://api.planx.dev/proxy/ordnance-survey" />`,
+      template: `<address-autocomplete postcode="SE19 1NT" osPlacesApiKey="" osProxyEndpoint="https://api.editor.planx.dev/proxy/ordnance-survey" />`,
       controller: function (document) {
         const autocomplete = document.querySelector("address-autocomplete");
 

--- a/src/components/address-autocomplete/index.ts
+++ b/src/components/address-autocomplete/index.ts
@@ -119,8 +119,6 @@ export class AddressAutocomplete extends LitElement {
       params,
     });
 
-    if (!url) throw Error("Unable to fetch from OS Places API");
-
     await fetch(url)
       .then((resp) => resp.json())
       .then((data) => {

--- a/src/components/address-autocomplete/index.ts
+++ b/src/components/address-autocomplete/index.ts
@@ -34,7 +34,6 @@ export class AddressAutocomplete extends LitElement {
   @property({ type: String })
   osPlacesApiKey = import.meta.env.VITE_APP_OS_PLACES_API_KEY || "";
 
-  // TODO: Docs
   @property({ type: String })
   osProxyEndpoint = "";
 

--- a/src/components/address-autocomplete/index.ts
+++ b/src/components/address-autocomplete/index.ts
@@ -3,6 +3,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import accessibleAutocomplete from "accessible-autocomplete";
 
 import styles from "./styles.scss";
+import { getServiceURL } from "../../lib/ordnanceSurvey";
 
 // https://apidocs.os.uk/docs/os-places-lpi-output
 type Address = {
@@ -32,6 +33,10 @@ export class AddressAutocomplete extends LitElement {
 
   @property({ type: String })
   osPlacesApiKey = import.meta.env.VITE_APP_OS_PLACES_API_KEY || "";
+
+  // TODO: Docs
+  @property({ type: String })
+  osProxyEndpoint = "";
 
   @property({ type: String })
   arrowStyle: ArrowStyleEnum = "default";
@@ -105,13 +110,18 @@ export class AddressAutocomplete extends LitElement {
       maxResults: "100",
       output_srs: "EPSG:4326",
       lr: "EN",
-      key: this.osPlacesApiKey,
+      offset: offset.toString(),
     };
-    const url = `https://api.os.uk/search/places/v1/postcode?${new URLSearchParams(
-      params
-    )}`;
+    const url = getServiceURL({
+      service: "places",
+      apiKey: this.osPlacesApiKey,
+      proxyEndpoint: this.osProxyEndpoint,
+      params,
+    });
 
-    await fetch(url + `&offset=${offset}`)
+    if (!url) throw Error("Unable to fetch from OS Places API");
+
+    await fetch(url)
       .then((resp) => resp.json())
       .then((data) => {
         // handle error formats returned by OS
@@ -224,7 +234,8 @@ export class AddressAutocomplete extends LitElement {
   render() {
     // handle various error states
     let errorMessage;
-    if (!this.osPlacesApiKey) errorMessage = "Missing OS Places API key";
+    if (!this.osPlacesApiKey && !this.osProxyEndpoint)
+      errorMessage = "Missing OS Places API key or proxy endpoint";
     else if (this._osError) errorMessage = this._osError;
     else if (this._totalAddresses === 0)
       errorMessage = `No addresses found in postcode ${this.postcode}`;

--- a/src/components/address-autocomplete/index.ts
+++ b/src/components/address-autocomplete/index.ts
@@ -103,6 +103,10 @@ export class AddressAutocomplete extends LitElement {
   }
 
   async _fetchData(offset: number = 0, prevResults: Address[] = []) {
+    const isUsingOS = Boolean(this.osPlacesApiKey || this.osProxyEndpoint);
+    if (!isUsingOS)
+      throw Error("OS Places API key or OS proxy endpoint not found");
+
     // https://apidocs.os.uk/docs/os-places-service-metadata
     const params: Record<string, string> = {
       postcode: this.postcode,

--- a/src/components/address-autocomplete/main.test.ts
+++ b/src/components/address-autocomplete/main.test.ts
@@ -94,23 +94,22 @@ describe("External API calls", async () => {
     document.body.innerHTML = `<address-autocomplete id="autocomplete-vitest" postcode="SE5 0HU" osPlacesApiKey="" osProxyEndpoint="https://www.my-site.com/api/v1/os" />`;
     await window.happyDOM.whenAsyncComplete();
 
-    expect(fetchSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "https://www.my-site.com/api/v1/os/search/places/v1/postcode?postcode=SE5+0HU"
-      )
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(fetchSpy.mock.lastCall?.[0]).toContain(
+      "https://www.my-site.com/api/v1/os/search/places/v1/postcode?postcode=SE5+0HU"
     );
+    expect(fetchSpy.mock.lastCall?.[0]).not.toContain("&key=");
   });
 
   it("calls OS API when 'osPlacesApiKey' provided", async () => {
-    document.body.innerHTML = `<address-autocomplete id="autocomplete-vitest" postcode="SE5 0HU" osPlacesApiKey=${
-      import.meta.env.VITE_APP_OS_PLACES_API_KEY
-    } />`;
+    const mockAPIKey = "test-test-test";
+    document.body.innerHTML = `<address-autocomplete id="autocomplete-vitest" postcode="SE5 0HU" osPlacesApiKey=${mockAPIKey} />`;
     await window.happyDOM.whenAsyncComplete();
 
-    expect(fetchSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "https://api.os.uk/search/places/v1/postcode?postcode=SE5+0HU"
-      )
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(fetchSpy.mock.lastCall?.[0]).toContain(
+      "https://api.os.uk/search/places/v1/postcode?postcode=SE5+0HU"
     );
+    expect(fetchSpy.mock.lastCall?.[0]).toContain(`&key=${mockAPIKey}`);
   });
 });

--- a/src/components/address-autocomplete/main.test.ts
+++ b/src/components/address-autocomplete/main.test.ts
@@ -80,3 +80,37 @@ describe("AddressAutocomplete on initial render with empty postcode", async () =
     );
   });
 });
+
+describe("External API calls", async () => {
+  const fetchSpy = vi.spyOn(window, "fetch").mockResolvedValue({
+    json: async () => ({ header: {}, results: [] }),
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls proxy when 'osProxyEndpoint' provided", async () => {
+    document.body.innerHTML = `<address-autocomplete id="autocomplete-vitest" postcode="SE5 0HU" osPlacesApiKey="" osProxyEndpoint="https://www.my-site.com/api/v1/os" />`;
+    await window.happyDOM.whenAsyncComplete();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "https://www.my-site.com/api/v1/os/search/places/v1/postcode?postcode=SE5+0HU"
+      )
+    );
+  });
+
+  it("calls OS API when 'osPlacesApiKey' provided", async () => {
+    document.body.innerHTML = `<address-autocomplete id="autocomplete-vitest" postcode="SE5 0HU" osPlacesApiKey=${
+      import.meta.env.VITE_APP_OS_PLACES_API_KEY
+    } />`;
+    await window.happyDOM.whenAsyncComplete();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "https://api.os.uk/search/places/v1/postcode?postcode=SE5+0HU"
+      )
+    );
+  });
+});

--- a/src/components/my-map/docs/my-map-basic.doc.js
+++ b/src/components/my-map/docs/my-map-basic.doc.js
@@ -84,7 +84,7 @@ module.exports = {
     {
       name: "osProxyEndpoint",
       type: "String",
-      values: "https://api.planx.dev/proxy/ordnance-survey",
+      values: "https://api.editor.planx.dev/proxy/ordnance-survey",
     },
   ],
   examples: [

--- a/src/components/my-map/docs/my-map-basic.doc.js
+++ b/src/components/my-map/docs/my-map-basic.doc.js
@@ -84,7 +84,7 @@ module.exports = {
     {
       name: "osProxyEndpoint",
       type: "String",
-      values: "https://api.1334.planx.pizza/proxy/ordnance-survey",
+      values: "https://api.planx.dev/proxy/ordnance-survey",
     },
   ],
   examples: [

--- a/src/components/my-map/docs/my-map-draw.doc.js
+++ b/src/components/my-map/docs/my-map-draw.doc.js
@@ -41,7 +41,7 @@ module.exports = {
     {
       name: "osProxyEndpoint",
       type: "String",
-      values: "https://api.planx.dev/proxy/ordnance-survey",
+      values: "https://api.editor.planx.dev/proxy/ordnance-survey",
     },
   ],
   examples: [

--- a/src/components/my-map/docs/my-map-draw.doc.js
+++ b/src/components/my-map/docs/my-map-draw.doc.js
@@ -38,6 +38,11 @@ module.exports = {
       type: "String",
       values: "https://osdatahub.os.uk/plans",
     },
+    {
+      name: "osProxyEndpoint",
+      type: "String",
+      values: "https://api.1334.planx.pizza/proxy/ordnance-survey",
+    },
   ],
   examples: [
     {

--- a/src/components/my-map/docs/my-map-draw.doc.js
+++ b/src/components/my-map/docs/my-map-draw.doc.js
@@ -41,7 +41,7 @@ module.exports = {
     {
       name: "osProxyEndpoint",
       type: "String",
-      values: "https://api.1334.planx.pizza/proxy/ordnance-survey",
+      values: "https://api.planx.dev/proxy/ordnance-survey",
     },
   ],
   examples: [

--- a/src/components/my-map/docs/my-map-features.doc.js
+++ b/src/components/my-map/docs/my-map-features.doc.js
@@ -41,7 +41,7 @@ module.exports = {
     {
       name: "osProxyEndpoint",
       type: "String",
-      values: "https://api.planx.dev/proxy/ordnance-survey",
+      values: "https://api.editor.planx.dev/proxy/ordnance-survey",
     },
   ],
   examples: [

--- a/src/components/my-map/docs/my-map-features.doc.js
+++ b/src/components/my-map/docs/my-map-features.doc.js
@@ -38,6 +38,11 @@ module.exports = {
       type: "String",
       values: "https://osdatahub.os.uk/plans",
     },
+    {
+      name: "osProxyEndpoint",
+      type: "String",
+      values: "https://api.1334.planx.pizza/proxy/ordnance-survey",
+    },
   ],
   examples: [
     {

--- a/src/components/my-map/docs/my-map-features.doc.js
+++ b/src/components/my-map/docs/my-map-features.doc.js
@@ -41,7 +41,7 @@ module.exports = {
     {
       name: "osProxyEndpoint",
       type: "String",
-      values: "https://api.1334.planx.pizza/proxy/ordnance-survey",
+      values: "https://api.planx.dev/proxy/ordnance-survey",
     },
   ],
   examples: [

--- a/src/components/my-map/docs/my-map-geojson.doc.js
+++ b/src/components/my-map/docs/my-map-geojson.doc.js
@@ -32,7 +32,7 @@ module.exports = {
     {
       name: "osProxyEndpoint",
       type: "String",
-      values: "https://api.planx.dev/proxy/ordnance-survey",
+      values: "https://api.editor.planx.dev/proxy/ordnance-survey",
     },
   ],
   examples: [

--- a/src/components/my-map/docs/my-map-geojson.doc.js
+++ b/src/components/my-map/docs/my-map-geojson.doc.js
@@ -32,7 +32,7 @@ module.exports = {
     {
       name: "osProxyEndpoint",
       type: "String",
-      values: "https://api.1334.planx.pizza/proxy/ordnance-survey",
+      values: "https://api.planx.dev/proxy/ordnance-survey",
     },
   ],
   examples: [

--- a/src/components/my-map/docs/my-map-geojson.doc.js
+++ b/src/components/my-map/docs/my-map-geojson.doc.js
@@ -29,6 +29,11 @@ module.exports = {
       type: "Number",
       values: "12",
     },
+    {
+      name: "osProxyEndpoint",
+      type: "String",
+      values: "https://api.1334.planx.pizza/proxy/ordnance-survey",
+    },
   ],
   examples: [
     {

--- a/src/components/my-map/docs/my-map-proxy.doc.js
+++ b/src/components/my-map/docs/my-map-proxy.doc.js
@@ -84,7 +84,7 @@ module.exports = {
     {
       name: "osProxyEndpoint",
       type: "String",
-      values: "https://api.planx.dev/proxy/ordnance-survey",
+      values: "https://api.editor.planx.dev/proxy/ordnance-survey",
     },
   ],
   examples: [
@@ -92,13 +92,13 @@ module.exports = {
       title: "Basemap: Ordnance Survey vector tiles (proxied)",
       description:
         "Calls the Ordnance Survey Vector Tiles API via the supplied proxy endpoint. The proxy must append a valid Ordnance Survey API key to each request.",
-      template: `<my-map zoom="18" osProxyEndpoint="https://api.planx.dev/proxy/ordnance-survey"/>`,
+      template: `<my-map zoom="18" osProxyEndpoint="https://api.editor.planx.dev/proxy/ordnance-survey"/>`,
     },
     {
       title: "Basemap: Ordnance Survey raster tiles (proxied)",
       description:
         "Calls the Ordnance Survey Maps API via the supplied proxy endpoint. The proxy must append a valid Ordnance Survey API key to each request.",
-      template: `<my-map zoom="18" osVectorTilesApiKey="" disableVectorTiles osProxyEndpoint="https://api.planx.dev/proxy/ordnance-survey"/>`,
+      template: `<my-map zoom="18" osVectorTilesApiKey="" disableVectorTiles osProxyEndpoint="https://api.editor.planx.dev/proxy/ordnance-survey"/>`,
     },
   ],
 };

--- a/src/components/my-map/docs/my-map-proxy.doc.js
+++ b/src/components/my-map/docs/my-map-proxy.doc.js
@@ -1,7 +1,7 @@
 module.exports = {
   name: "MyMap - Proxy",
   description:
-    "The MyMap component can either call the Ordnance Survey API directly, or via a proxy. Calling the API directly may be suitable for internal use, where exposure of API keys is not a concern, whilst calling a proxy may be more suitable for public use. Any proxy supplied via the osProxyEndpoint property must append a valid Ordnance Survey API key to all requests. For full implementation details, please see XXXX",
+    "The MyMap component can either call the Ordnance Survey API directly, or via a proxy. Calling the API directly may be suitable for internal use, where exposure of API keys is not a concern, whilst calling a proxy may be more suitable for public use. Any proxy supplied via the osProxyEndpoint property must append a valid Ordnance Survey API key to all requests. For full implementation details, please see https://github.com/theopensystemslab/map/blob/main/docs/how-to-use-a-proxy.md",
   properties: [
     {
       name: "latitude",
@@ -84,7 +84,7 @@ module.exports = {
     {
       name: "osProxyEndpoint",
       type: "String",
-      values: "https://api.1334.planx.pizza/proxy/ordnance-survey",
+      values: "https://api.planx.dev/proxy/ordnance-survey",
     },
   ],
   examples: [
@@ -92,13 +92,13 @@ module.exports = {
       title: "Basemap: Ordnance Survey vector tiles (proxied)",
       description:
         "Calls the Ordnance Survey Vector Tiles API via the supplied proxy endpoint. The proxy must append a valid Ordnance Survey API key to each request.",
-      template: `<my-map zoom="18" osProxyEndpoint="https://api.1334.planx.pizza/proxy/ordnance-survey"/>`,
+      template: `<my-map zoom="18" osProxyEndpoint="https://api.planx.dev/proxy/ordnance-survey"/>`,
     },
     {
       title: "Basemap: Ordnance Survey raster tiles (proxied)",
       description:
         "Calls the Ordnance Survey Maps API via the supplied proxy endpoint. The proxy must append a valid Ordnance Survey API key to each request.",
-      template: `<my-map zoom="18" osVectorTilesApiKey="" disableVectorTiles osProxyEndpoint="https://api.1334.planx.pizza/proxy/ordnance-survey"/>`,
+      template: `<my-map zoom="18" osVectorTilesApiKey="" disableVectorTiles osProxyEndpoint="https://api.planx.dev/proxy/ordnance-survey"/>`,
     },
   ],
 };

--- a/src/components/my-map/docs/my-map-proxy.doc.js
+++ b/src/components/my-map/docs/my-map-proxy.doc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  name: "MyMap - Basic",
+  name: "MyMap - Proxy",
   description:
-    "MyMap is an OpenLayers-powered Lit web component map for tasks related to planning permission in the UK. These examples cover the foundational properties used to render and style the map.",
+    "The MyMap component can either call the Ordnance Survey API directly, or via a proxy. Calling the API directly may be suitable for internal use, where exposure of API keys is not a concern, whilst calling a proxy may be more suitable for public use. Any proxy supplied via the osProxyEndpoint property must append a valid Ordnance Survey API key to all requests. For full implementation details, please see XXXX",
   properties: [
     {
       name: "latitude",
@@ -89,38 +89,16 @@ module.exports = {
   ],
   examples: [
     {
-      title: "Basemap: Ordnance Survey vector tiles",
+      title: "Basemap: Ordnance Survey vector tiles (proxied)",
       description:
-        "Requires access to the Ordnance Survey Vector Tiles API, fallsback to OpenStreetMap basemap if no key is provided.",
-      template: `<my-map zoom="18" osVectorTilesApiKey="" />`,
+        "Calls the Ordnance Survey Vector Tiles API via the supplied proxy endpoint. The proxy must append a valid Ordnance Survey API key to each request.",
+      template: `<my-map zoom="18" osProxyEndpoint="https://api.1334.planx.pizza/proxy/ordnance-survey"/>`,
     },
     {
-      title: "Basemap: Ordnance Survey raster tiles",
+      title: "Basemap: Ordnance Survey raster tiles (proxied)",
       description:
-        "Requires access to the Ordnance Survey Maps API, fallsback to OpenStreetMap basemap if no key provided.",
-      template: `<my-map zoom="18" osVectorTilesApiKey="" disableVectorTiles />`,
-    },
-    {
-      title: "Display a static map",
-      description:
-        "Disable zooming, panning, and other map interactions. Hide the reset control button.",
-      template: `
-        <my-map
-          zoom="20"
-          staticMode
-          hideResetControl
-          osVectorTilesApiKey="" />`,
-    },
-    {
-      title: "Display a scale bar on the map",
-      description:
-        'Display a scale bar on the map for orientation, choose between the default or "bar" styles offered by OpenLayers',
-      template: `
-        <my-map
-          zoom="20"
-          showScale
-          useScaleBarStyle
-          osVectorTilesApiKey="" />`,
+        "Calls the Ordnance Survey Maps API via the supplied proxy endpoint. The proxy must append a valid Ordnance Survey API key to each request.",
+      template: `<my-map zoom="18" osVectorTilesApiKey="" disableVectorTiles osProxyEndpoint="https://api.1334.planx.pizza/proxy/ordnance-survey"/>`,
     },
   ],
 };

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -147,7 +147,9 @@ export class MyMap extends LitElement {
   @property({ type: String })
   osFeaturesApiKey = import.meta.env.VITE_APP_OS_FEATURES_API_KEY || "";
 
-  // TODO: Docs
+  @property({ type: String })
+  osCopyright = `© Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`;
+
   @property({ type: String })
   osProxyEndpoint = "";
 
@@ -186,11 +188,13 @@ export class MyMap extends LitElement {
 
     const rasterBaseMap = makeRasterBaseMap(
       this.osVectorTilesApiKey,
-      this.osProxyEndpoint
+      this.osProxyEndpoint,
+      this.osCopyright
     );
     const osVectorTileBaseMap = makeOsVectorTileBaseMap(
       this.osVectorTilesApiKey,
-      this.osProxyEndpoint
+      this.osProxyEndpoint,
+      this.osCopyright
     );
 
     const useVectorTiles =

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -147,8 +147,9 @@ export class MyMap extends LitElement {
   @property({ type: String })
   osFeaturesApiKey = import.meta.env.VITE_APP_OS_FEATURES_API_KEY || "";
 
+  // TODO: Docs
   @property({ type: String })
-  osCopyright = `© Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`;
+  osProxyEndpoint = "";
 
   @property({ type: Boolean })
   hideResetControl = false;
@@ -187,12 +188,12 @@ export class MyMap extends LitElement {
       !this.disableVectorTiles && Boolean(this.osVectorTilesApiKey);
 
     const rasterBaseMap = makeRasterBaseMap(
-      this.osCopyright,
-      this.osVectorTilesApiKey
+      this.osVectorTilesApiKey,
+      this.osProxyEndpoint
     );
     const osVectorTileBaseMap = makeOsVectorTileBaseMap(
-      this.osCopyright,
-      this.osVectorTilesApiKey
+      this.osVectorTilesApiKey,
+      this.osProxyEndpoint
     );
 
     // @ts-ignore

--- a/src/components/my-map/main.test.ts
+++ b/src/components/my-map/main.test.ts
@@ -6,19 +6,13 @@ import Point from "ol/geom/Point";
 import VectorSource from "ol/source/Vector";
 import waitForExpect from "wait-for-expect";
 
-import { getShadowRoot } from "../../test-utils";
+import { getShadowRoot, setupMap } from "../../test-utils";
 import * as snapping from "./snapping";
 import "./index";
 
 declare global {
   interface Window extends IWindow {}
 }
-
-const setupMap = async (mapElement: any) => {
-  document.body.innerHTML = mapElement;
-  await window.happyDOM.whenAsyncComplete();
-  window.olMap?.dispatchEvent("loadend");
-};
 
 test("olMap is added to the global window for tests", async () => {
   await setupMap(`<my-map id="map-vitest" disableVectorTiles />`);

--- a/src/components/my-map/os-layers.test.ts
+++ b/src/components/my-map/os-layers.test.ts
@@ -13,79 +13,6 @@ declare global {
   interface Window extends IWindow {}
 }
 
-describe("constructURL helper function", () => {
-  test("simple URL construction", () => {
-    const result = constructURL(
-      "https://www.test.com",
-      "/my-path/to-something"
-    );
-    expect(result).toEqual("https://www.test.com/my-path/to-something");
-  });
-
-  test("URL with query params construction", () => {
-    const result = constructURL(
-      "https://www.test.com",
-      "/my-path/to-something",
-      { test: "params", test2: "more-params" }
-    );
-    expect(result).toEqual(
-      "https://www.test.com/my-path/to-something?test=params&test2=more-params"
-    );
-  });
-});
-
-describe("getServiceURL helper function", () => {
-  it("returns an OS service URL if an API key is passed in", () => {
-    const result = getServiceURL({
-      service: "vectorTile",
-      apiKey: "my-api-key",
-    });
-
-    expect(result).toBeDefined();
-    const { origin, pathname, searchParams } = new URL(result!);
-    expect(origin).toEqual("https://api.os.uk");
-    expect(decodeURIComponent(pathname)).toEqual(
-      "/maps/vector/v1/vts/tile/{z}/{y}/{x}.pbf"
-    );
-    expect(searchParams.get("key")).toEqual("my-api-key");
-    expect(searchParams.get("srs")).toEqual("3857");
-  });
-
-  it("returns a proxy service URL if a proxy endpoint is passed in", () => {
-    const result = getServiceURL({
-      service: "vectorTileStyle",
-      proxyEndpoint: "https://www.my-site.com/api/proxy/os",
-    });
-
-    expect(result).toBeDefined();
-    const { origin, pathname, searchParams } = new URL(result!);
-    expect(origin).toEqual("https://www.my-site.com");
-    expect(decodeURIComponent(pathname)).toEqual(
-      "/api/proxy/os/maps/vector/v1/vts/resources/styles"
-    );
-    expect(searchParams.get("srs")).toEqual("3857");
-  });
-
-  it("returns a proxy service URL if a proxy endpoint is passed in (with a trailing slash)", () => {
-    const result = getServiceURL({
-      service: "xyz",
-      proxyEndpoint: "https://www.my-site.com/api/proxy/os/",
-    });
-
-    expect(result).toBeDefined();
-    const { origin, pathname } = new URL(result!);
-    expect(origin).toEqual("https://www.my-site.com");
-    expect(decodeURIComponent(pathname)).toEqual(
-      "/api/proxy/os/maps/raster/v1/zxy/Light_3857/{z}/{x}/{y}.png"
-    );
-  });
-
-  it("returns undefined without an API key or proxy endpoint", () => {
-    const result = getServiceURL({ service: "xyz" });
-    expect(result).toBeUndefined();
-  });
-});
-
 describe("OS Layer loading", () => {
   afterEach(() => {
     vi.resetAllMocks();
@@ -139,4 +66,8 @@ describe("OS Layer loading", () => {
       "https://www.my-site.com/api/v1/os/maps/vector/v1/vts/resources/styles?srs=3857"
     );
   });
+
+  it.todo(
+    "falls back to an OSM basemap without an OS API key or proxy endpoint"
+  );
 });

--- a/src/components/my-map/os-layers.test.ts
+++ b/src/components/my-map/os-layers.test.ts
@@ -1,4 +1,4 @@
-import { constructURL } from "./os-layers";
+import { constructURL, getServiceURL } from "./os-layers";
 
 describe("constructURL helper function", () => {
   test("simple URL construction", () => {
@@ -18,5 +18,57 @@ describe("constructURL helper function", () => {
     expect(result).toEqual(
       "https://www.test.com/my-path/to-something?test=params&test2=more-params"
     );
+  });
+});
+
+describe("getServiceURL helper function", () => {
+  it("returns an OS service URL if an API key is passed in", () => {
+    const result = getServiceURL({
+      service: "vectorTile",
+      apiKey: "my-api-key",
+    });
+
+    expect(result).toBeDefined();
+    const { origin, pathname, searchParams } = new URL(result!);
+    expect(origin).toEqual("https://api.os.uk");
+    expect(decodeURIComponent(pathname)).toEqual(
+      "/maps/vector/v1/vts/tile/{z}/{y}/{x}.pbf"
+    );
+    expect(searchParams.get("key")).toEqual("my-api-key");
+    expect(searchParams.get("srs")).toEqual("3857");
+  });
+
+  it("returns a proxy service URL if a proxy endpoint is passed in", () => {
+    const result = getServiceURL({
+      service: "vectorTileStyle",
+      proxyEndpoint: "https://www.my-site.com/api/proxy/os",
+    });
+
+    expect(result).toBeDefined();
+    const { origin, pathname, searchParams } = new URL(result!);
+    expect(origin).toEqual("https://www.my-site.com");
+    expect(decodeURIComponent(pathname)).toEqual(
+      "/api/proxy/os/maps/vector/v1/vts/resources/styles"
+    );
+    expect(searchParams.get("srs")).toEqual("3857");
+  });
+
+  it("returns a proxy service URL if a proxy endpoint is passed in (with a trailing slash)", () => {
+    const result = getServiceURL({
+      service: "xyz",
+      proxyEndpoint: "https://www.my-site.com/api/proxy/os/",
+    });
+
+    expect(result).toBeDefined();
+    const { origin, pathname } = new URL(result!);
+    expect(origin).toEqual("https://www.my-site.com");
+    expect(decodeURIComponent(pathname)).toEqual(
+      "/api/proxy/os/maps/raster/v1/zxy/Light_3857/{z}/{x}/{y}.png"
+    );
+  });
+
+  it("returns undefined without an API key or proxy endpoint", () => {
+    const result = getServiceURL({ service: "xyz" });
+    expect(result).toBeUndefined();
   });
 });

--- a/src/components/my-map/os-layers.test.ts
+++ b/src/components/my-map/os-layers.test.ts
@@ -1,4 +1,17 @@
+import "./index";
 import { constructURL, getServiceURL } from "./os-layers";
+import { setupMap } from "../../test-utils";
+
+import VectorTileSource from "ol/source/VectorTile";
+import type { IWindow } from "happy-dom";
+
+declare global {
+  interface Window extends IWindow {}
+}
+
+declare global {
+  interface Window extends IWindow {}
+}
 
 describe("constructURL helper function", () => {
   test("simple URL construction", () => {
@@ -70,5 +83,60 @@ describe("getServiceURL helper function", () => {
   it("returns undefined without an API key or proxy endpoint", () => {
     const result = getServiceURL({ service: "xyz" });
     expect(result).toBeUndefined();
+  });
+});
+
+describe("OS Layer loading", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("requests layers directly from OS when an API key is provided", async () => {
+    const apiKey = process.env.VITE_APP_OS_VECTOR_TILES_API_KEY;
+    await setupMap(`
+      <my-map 
+        id="map-vitest" 
+        osVectorTileApiKey=${apiKey}
+      />`);
+    const vectorBaseMap = window.olMap
+      ?.getAllLayers()
+      .find((layer) => layer.get("name") === "vectorBaseMap");
+    expect(vectorBaseMap).toBeDefined();
+    const source = vectorBaseMap?.getSource() as VectorTileSource;
+    expect(source.getUrls()).toHaveLength(1);
+    expect(source.getUrls()?.[0]).toEqual(
+      expect.stringMatching(/^https:\/\/api.os.uk/)
+    );
+    expect(source.getUrls()?.[0]).toEqual(
+      expect.stringContaining(`key=${apiKey}`)
+    );
+  });
+
+  it("requests layers via proxy when an API key is not provided", async () => {
+    const fetchSpy = vi.spyOn(window, "fetch").mockResolvedValue({
+      json: async () => ({ version: 8, layers: [] }),
+    });
+
+    const osProxyEndpoint = "https://www.my-site.com/api/v1/os";
+    await setupMap(`
+      <my-map 
+        id="map-vitest" 
+        osProxyEndpoint=${osProxyEndpoint}
+      />`);
+    const vectorBaseMap = window.olMap
+      ?.getAllLayers()
+      .find((layer) => layer.get("name") === "vectorBaseMap");
+    expect(vectorBaseMap).toBeDefined();
+    const source = vectorBaseMap?.getSource() as VectorTileSource;
+
+    // Tiles are being requested via proxy
+    expect(source.getUrls()).toHaveLength(1);
+    expect(source.getUrls()?.[0]).toEqual(
+      expect.stringContaining(osProxyEndpoint)
+    );
+    // Style is being fetched via proxy
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://www.my-site.com/api/v1/os/maps/vector/v1/vts/resources/styles?srs=3857"
+    );
   });
 });

--- a/src/components/my-map/os-layers.test.ts
+++ b/src/components/my-map/os-layers.test.ts
@@ -1,5 +1,4 @@
 import "./index";
-import { constructURL, getServiceURL } from "./os-layers";
 import { setupMap } from "../../test-utils";
 
 import VectorTileSource from "ol/source/VectorTile";

--- a/src/components/my-map/os-layers.test.ts
+++ b/src/components/my-map/os-layers.test.ts
@@ -1,6 +1,7 @@
 import "./index";
 import { setupMap } from "../../test-utils";
 
+import { OSM } from "ol/source";
 import VectorTileSource from "ol/source/VectorTile";
 import type { IWindow } from "happy-dom";
 
@@ -66,7 +67,17 @@ describe("OS Layer loading", () => {
     );
   });
 
-  it.todo(
-    "falls back to an OSM basemap without an OS API key or proxy endpoint"
-  );
+  it("falls back to an OSM basemap without an OS API key or proxy endpoint", async () => {
+    await setupMap(`
+      <my-map id="map-vitest" disableVectorTiles osVectorTilesApiKey=""/>`);
+    const rasterBaseMap = window.olMap
+      ?.getAllLayers()
+      .find((layer) => layer.get("name") === "rasterBaseMap");
+    expect(rasterBaseMap).toBeDefined();
+    const source = rasterBaseMap?.getSource() as OSM;
+    expect(source.getUrls()?.length).toBeGreaterThan(0);
+    source
+      .getUrls()
+      ?.forEach((url) => expect(url).toMatch(/openstreetmap\.org/));
+  });
 });

--- a/src/components/my-map/os-layers.test.ts
+++ b/src/components/my-map/os-layers.test.ts
@@ -1,0 +1,22 @@
+import { constructURL } from "./os-layers";
+
+describe("constructURL helper function", () => {
+  test("simple URL construction", () => {
+    const result = constructURL(
+      "https://www.test.com",
+      "/my-path/to-something"
+    );
+    expect(result).toEqual("https://www.test.com/my-path/to-something");
+  });
+
+  test("URL with query params construction", () => {
+    const result = constructURL(
+      "https://www.test.com",
+      "/my-path/to-something",
+      { test: "params", test2: "more-params" }
+    );
+    expect(result).toEqual(
+      "https://www.test.com/my-path/to-something?test=params&test2=more-params"
+    );
+  });
+});

--- a/src/components/my-map/os-layers.ts
+++ b/src/components/my-map/os-layers.ts
@@ -69,7 +69,6 @@ export function getProxyServiceURL(
   return serviceURLLookup[service];
 }
 
-// Assumption: If you provide an API key this takes precedent over a proxy?
 export function getServiceURL({
   service,
   apiKey,
@@ -79,8 +78,8 @@ export function getServiceURL({
   apiKey?: string;
   proxyEndpoint?: string;
 }): string | undefined {
-  if (apiKey) return getOSServiceURL(service, apiKey);
   if (proxyEndpoint) return getProxyServiceURL(service, proxyEndpoint);
+  if (apiKey) return getOSServiceURL(service, apiKey);
   return;
 }
 
@@ -91,6 +90,9 @@ export function makeRasterBaseMap(apiKey: string, proxyEndpoint: string) {
     proxyEndpoint,
   });
   return new TileLayer({
+    properties: {
+      name: "rasterBaseMap",
+    },
     source: tileServiceURL
       ? new XYZ({
           url: tileServiceURL,
@@ -113,6 +115,9 @@ export function makeOsVectorTileBaseMap(apiKey: string, proxyEndpoint: string) {
   });
   const osVectorTileLayer = new VectorTileLayer({
     declutter: true,
+    properties: {
+      name: "vectorBaseMap",
+    },
     source: new VectorTileSource({
       format: new MVT(),
       url: vectorTileServiceUrl,

--- a/src/components/my-map/os-layers.ts
+++ b/src/components/my-map/os-layers.ts
@@ -38,6 +38,7 @@ export function makeOsVectorTileBaseMap(apiKey: string, proxyEndpoint: string) {
     service: "vectorTile",
     apiKey,
     proxyEndpoint,
+    params: { srs: "3857" },
   });
   const osVectorTileLayer = new VectorTileLayer({
     declutter: true,
@@ -56,6 +57,7 @@ export function makeOsVectorTileBaseMap(apiKey: string, proxyEndpoint: string) {
     service: "vectorTileStyle",
     apiKey,
     proxyEndpoint,
+    params: { srs: "3857" },
   });
   if (vectorTileStyleUrl) {
     // ref https://github.com/openlayers/ol-mapbox-style#usage-example

--- a/src/components/my-map/os-layers.ts
+++ b/src/components/my-map/os-layers.ts
@@ -6,16 +6,46 @@ import { OSM, XYZ } from "ol/source";
 import { ATTRIBUTION } from "ol/source/OSM";
 import VectorTileSource from "ol/source/VectorTile";
 
-// Ordnance Survey sources
-const tileServiceUrl = `https://api.os.uk/maps/raster/v1/zxy/Light_3857/{z}/{x}/{y}.png?key=`;
-const vectorTileServiceUrl = `https://api.os.uk/maps/vector/v1/vts/tile/{z}/{y}/{x}.pbf?srs=3857&key=`;
-const vectorTileStyleUrl = `https://api.os.uk/maps/vector/v1/vts/resources/styles?srs=3857&key=`;
+const OS_DOMAIN = "https://api.os.uk";
+type OSServices = "xyz" | "vectorTile" | "vectorTileStyle";
 
-export function makeRasterBaseMap(copyright: string, apiKey?: string) {
+// Ordnance Survey sources
+const tileServicePath = `/maps/raster/v1/zxy/Light_3857/{z}/{x}/{y}.png`;
+const vectorTileServicePath = `/maps/vector/v1/vts/tile/{z}/{y}/{x}.pbf`;
+const vectorTileStylePath = `/maps/vector/v1/vts/resources/styles`;
+
+export function constructURL(
+  domain: string,
+  path: string,
+  params: Record<string, string> = {}
+): string {
+  const url = new URL(path, domain);
+  url.search = new URLSearchParams(params).toString();
+  return url.href;
+}
+
+export function getOSServiceURL(service: OSServices, apiKey: string): string {
+  const serviceURLLookup = {
+    xyz: constructURL(OS_DOMAIN, tileServicePath, { key: apiKey }),
+    vectorTile: constructURL(OS_DOMAIN, vectorTileServicePath, {
+      key: apiKey,
+      srs: "3857",
+    }),
+    vectorTileStyle: constructURL(OS_DOMAIN, vectorTileStylePath, {
+      key: apiKey,
+      srs: "3857",
+    }),
+  };
+  return serviceURLLookup[service];
+}
+
+export function makeRasterBaseMap(copyright: string, apiKey: string) {
+  const tileServiceURL = getOSServiceURL("xyz", apiKey);
+  // TODO: fix conditional API key
   return new TileLayer({
     source: apiKey
       ? new XYZ({
-          url: tileServiceUrl + apiKey,
+          url: tileServiceURL,
           attributions: [copyright],
           attributionsCollapsible: false,
           maxZoom: 20,
@@ -27,20 +57,26 @@ export function makeRasterBaseMap(copyright: string, apiKey?: string) {
   });
 }
 
-export function makeOsVectorTileBaseMap(copyright: string, apiKey: string) {
-  let osVectorTileLayer = new VectorTileLayer({
+export function makeOsVectorTileBaseMap(
+  copyright: string,
+  apiKey: string,
+  osProxyEndpoint?: string
+) {
+  const vectorTileServiceUrl = getOSServiceURL("vectorTile", apiKey);
+  const osVectorTileLayer = new VectorTileLayer({
     declutter: true,
     source: new VectorTileSource({
       format: new MVT(),
-      url: vectorTileServiceUrl + apiKey,
+      url: vectorTileServiceUrl,
       attributions: [copyright],
       attributionsCollapsible: false,
     }),
   });
 
   if (apiKey) {
+    const vectorTileStyleUrl = getOSServiceURL("vectorTileStyle", apiKey);
     // ref https://github.com/openlayers/ol-mapbox-style#usage-example
-    fetch(vectorTileStyleUrl + apiKey)
+    fetch(vectorTileStyleUrl)
       .then((response) => response.json())
       .then((glStyle) => stylefunction(osVectorTileLayer, glStyle, "esri"))
       .catch((error) => console.log(error));

--- a/src/components/my-map/os-layers.ts
+++ b/src/components/my-map/os-layers.ts
@@ -7,16 +7,15 @@ import { ATTRIBUTION } from "ol/source/OSM";
 import VectorTileSource from "ol/source/VectorTile";
 import { getServiceURL } from "../../lib/ordnanceSurvey";
 
-const OS_COPYRIGHT = `© Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`;
-
 export function makeRasterBaseMap(
   apiKey: string,
-  proxyEndpoint: string
+  proxyEndpoint: string,
+  copyright: string
 ): TileLayer<OSM> {
   const isUsingOS = Boolean(apiKey || proxyEndpoint);
   // Fallback to OSM if not using OS services
   const basemap = isUsingOS
-    ? makeOSRasterBaseMap(apiKey, proxyEndpoint)
+    ? makeOSRasterBaseMap(apiKey, proxyEndpoint, copyright)
     : makeOSMRasterBasemap();
   basemap.set("name", "rasterBaseMap");
   return basemap;
@@ -24,7 +23,8 @@ export function makeRasterBaseMap(
 
 function makeOSRasterBaseMap(
   apiKey: string,
-  proxyEndpoint: string
+  proxyEndpoint: string,
+  copyright: string
 ): TileLayer<XYZ> {
   const tileServiceURL = getServiceURL({
     service: "xyz",
@@ -34,7 +34,7 @@ function makeOSRasterBaseMap(
   return new TileLayer({
     source: new XYZ({
       url: tileServiceURL,
-      attributions: [OS_COPYRIGHT],
+      attributions: [copyright],
       attributionsCollapsible: false,
       maxZoom: 20,
     }),
@@ -51,7 +51,8 @@ function makeOSMRasterBasemap(): TileLayer<OSM> {
 
 export function makeOsVectorTileBaseMap(
   apiKey: string,
-  proxyEndpoint: string
+  proxyEndpoint: string,
+  copyright: string
 ): VectorTileLayer | undefined {
   const isUsingOS = Boolean(apiKey || proxyEndpoint);
   if (!isUsingOS) return;
@@ -70,7 +71,7 @@ export function makeOsVectorTileBaseMap(
     source: new VectorTileSource({
       format: new MVT(),
       url: vectorTileServiceUrl,
-      attributions: [OS_COPYRIGHT],
+      attributions: [copyright],
       attributionsCollapsible: false,
     }),
   });

--- a/src/components/my-map/os-layers.ts
+++ b/src/components/my-map/os-layers.ts
@@ -16,7 +16,7 @@ export function makeRasterBaseMap(
   // Fallback to OSM if not using OS services
   const basemap = isUsingOS
     ? makeOSRasterBaseMap(apiKey, proxyEndpoint, copyright)
-    : makeOSMRasterBasemap();
+    : makeDefaultTileLayer();
   basemap.set("name", "rasterBaseMap");
   return basemap;
 }
@@ -41,7 +41,7 @@ function makeOSRasterBaseMap(
   });
 }
 
-function makeOSMRasterBasemap(): TileLayer<OSM> {
+function makeDefaultTileLayer(): TileLayer<OSM> {
   return new TileLayer({
     source: new OSM({
       attributions: [ATTRIBUTION],

--- a/src/components/my-map/os-layers.ts
+++ b/src/components/my-map/os-layers.ts
@@ -5,83 +5,9 @@ import VectorTileLayer from "ol/layer/VectorTile";
 import { OSM, XYZ } from "ol/source";
 import { ATTRIBUTION } from "ol/source/OSM";
 import VectorTileSource from "ol/source/VectorTile";
-
-const OS_DOMAIN = "https://api.os.uk";
-type OSServices = "xyz" | "vectorTile" | "vectorTileStyle";
+import { getServiceURL } from "../../lib/ordnanceSurvey";
 
 const OS_COPYRIGHT = `© Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857`;
-
-// Ordnance Survey sources
-const tileServicePath = `/maps/raster/v1/zxy/Light_3857/{z}/{x}/{y}.png`;
-const vectorTileServicePath = `/maps/vector/v1/vts/tile/{z}/{y}/{x}.pbf`;
-const vectorTileStylePath = `/maps/vector/v1/vts/resources/styles`;
-
-export function constructURL(
-  domain: string,
-  path: string,
-  params: Record<string, string> = {}
-): string {
-  const url = new URL(path, domain);
-  url.search = new URLSearchParams(params).toString();
-  // OL requires that {z}/{x}/{y} are not encoded in order to substitue in real values
-  const openLayersURL = decodeURI(url.href);
-  return openLayersURL;
-}
-
-export function getOSServiceURL(service: OSServices, apiKey: string): string {
-  const serviceURLLookup = {
-    xyz: constructURL(OS_DOMAIN, tileServicePath, { key: apiKey }),
-    vectorTile: constructURL(OS_DOMAIN, vectorTileServicePath, {
-      key: apiKey,
-      srs: "3857",
-    }),
-    vectorTileStyle: constructURL(OS_DOMAIN, vectorTileStylePath, {
-      key: apiKey,
-      srs: "3857",
-    }),
-  };
-  return serviceURLLookup[service];
-}
-
-// OS API key must be appended to requests by the proxy endpoint
-// Please see docs: TODO!
-export function getProxyServiceURL(
-  service: OSServices,
-  proxyEndpoint: string
-): string {
-  let { origin: proxyOrigin, pathname: proxyPathname } = new URL(proxyEndpoint);
-  // Remove trailing slash on pathname if present
-  proxyPathname = proxyPathname.replace(/\/$/, "");
-
-  const serviceURLLookup = {
-    xyz: constructURL(proxyOrigin, proxyPathname + tileServicePath),
-    vectorTile: constructURL(
-      proxyOrigin,
-      proxyPathname + vectorTileServicePath,
-      { srs: "3857" }
-    ),
-    vectorTileStyle: constructURL(
-      proxyOrigin,
-      proxyPathname + vectorTileStylePath,
-      { srs: "3857" }
-    ),
-  };
-  return serviceURLLookup[service];
-}
-
-export function getServiceURL({
-  service,
-  apiKey,
-  proxyEndpoint,
-}: {
-  service: OSServices;
-  apiKey?: string;
-  proxyEndpoint?: string;
-}): string | undefined {
-  if (proxyEndpoint) return getProxyServiceURL(service, proxyEndpoint);
-  if (apiKey) return getOSServiceURL(service, apiKey);
-  return;
-}
 
 export function makeRasterBaseMap(apiKey: string, proxyEndpoint: string) {
   const tileServiceURL = getServiceURL({

--- a/src/lib/ordnanceSurvey.test.ts
+++ b/src/lib/ordnanceSurvey.test.ts
@@ -1,0 +1,74 @@
+import { constructURL, getServiceURL } from "./ordnanceSurvey";
+
+describe("constructURL helper function", () => {
+  test("simple URL construction", () => {
+    const result = constructURL(
+      "https://www.test.com",
+      "/my-path/to-something"
+    );
+    expect(result).toEqual("https://www.test.com/my-path/to-something");
+  });
+
+  test("URL with query params construction", () => {
+    const result = constructURL(
+      "https://www.test.com",
+      "/my-path/to-something",
+      { test: "params", test2: "more-params" }
+    );
+    expect(result).toEqual(
+      "https://www.test.com/my-path/to-something?test=params&test2=more-params"
+    );
+  });
+});
+
+describe("getServiceURL helper function", () => {
+  it("returns an OS service URL if an API key is passed in", () => {
+    const result = getServiceURL({
+      service: "vectorTile",
+      apiKey: "my-api-key",
+    });
+
+    expect(result).toBeDefined();
+    const { origin, pathname, searchParams } = new URL(result!);
+    expect(origin).toEqual("https://api.os.uk");
+    expect(decodeURIComponent(pathname)).toEqual(
+      "/maps/vector/v1/vts/tile/{z}/{y}/{x}.pbf"
+    );
+    expect(searchParams.get("key")).toEqual("my-api-key");
+    expect(searchParams.get("srs")).toEqual("3857");
+  });
+
+  it("returns a proxy service URL if a proxy endpoint is passed in", () => {
+    const result = getServiceURL({
+      service: "vectorTileStyle",
+      proxyEndpoint: "https://www.my-site.com/api/proxy/os",
+    });
+
+    expect(result).toBeDefined();
+    const { origin, pathname, searchParams } = new URL(result!);
+    expect(origin).toEqual("https://www.my-site.com");
+    expect(decodeURIComponent(pathname)).toEqual(
+      "/api/proxy/os/maps/vector/v1/vts/resources/styles"
+    );
+    expect(searchParams.get("srs")).toEqual("3857");
+  });
+
+  it("returns a proxy service URL if a proxy endpoint is passed in (with a trailing slash)", () => {
+    const result = getServiceURL({
+      service: "xyz",
+      proxyEndpoint: "https://www.my-site.com/api/proxy/os/",
+    });
+
+    expect(result).toBeDefined();
+    const { origin, pathname } = new URL(result!);
+    expect(origin).toEqual("https://www.my-site.com");
+    expect(decodeURIComponent(pathname)).toEqual(
+      "/api/proxy/os/maps/raster/v1/zxy/Light_3857/{z}/{x}/{y}.png"
+    );
+  });
+
+  it("returns undefined without an API key or proxy endpoint", () => {
+    const result = getServiceURL({ service: "xyz" });
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/lib/ordnanceSurvey.test.ts
+++ b/src/lib/ordnanceSurvey.test.ts
@@ -26,6 +26,8 @@ describe("getServiceURL helper function", () => {
     const result = getServiceURL({
       service: "vectorTile",
       apiKey: "my-api-key",
+      proxyEndpoint: "",
+      params: { srs: "3857" },
     });
 
     expect(result).toBeDefined();
@@ -42,6 +44,8 @@ describe("getServiceURL helper function", () => {
     const result = getServiceURL({
       service: "vectorTileStyle",
       proxyEndpoint: "https://www.my-site.com/api/proxy/os",
+      apiKey: "",
+      params: { srs: "3857" },
     });
 
     expect(result).toBeDefined();
@@ -57,6 +61,7 @@ describe("getServiceURL helper function", () => {
     const result = getServiceURL({
       service: "xyz",
       proxyEndpoint: "https://www.my-site.com/api/proxy/os/",
+      apiKey: "",
     });
 
     expect(result).toBeDefined();
@@ -68,7 +73,11 @@ describe("getServiceURL helper function", () => {
   });
 
   it("returns undefined without an API key or proxy endpoint", () => {
-    const result = getServiceURL({ service: "xyz" });
+    const result = getServiceURL({
+      service: "xyz",
+      apiKey: "",
+      proxyEndpoint: "",
+    });
     expect(result).toBeUndefined();
   });
 });

--- a/src/lib/ordnanceSurvey.test.ts
+++ b/src/lib/ordnanceSurvey.test.ts
@@ -54,6 +54,7 @@ describe("getServiceURL helper function", () => {
     expect(decodeURIComponent(pathname)).toEqual(
       "/api/proxy/os/maps/vector/v1/vts/resources/styles"
     );
+    expect(searchParams.get("key")).toBeNull();
     expect(searchParams.get("srs")).toEqual("3857");
   });
 

--- a/src/lib/ordnanceSurvey.test.ts
+++ b/src/lib/ordnanceSurvey.test.ts
@@ -72,12 +72,13 @@ describe("getServiceURL helper function", () => {
     );
   });
 
-  it("returns undefined without an API key or proxy endpoint", () => {
-    const result = getServiceURL({
-      service: "xyz",
-      apiKey: "",
-      proxyEndpoint: "",
-    });
-    expect(result).toBeUndefined();
+  it("throws error without an API key or proxy endpoint", () => {
+    expect(() =>
+      getServiceURL({
+        service: "xyz",
+        apiKey: "",
+        proxyEndpoint: "",
+      })
+    ).toThrowError();
   });
 });

--- a/src/lib/ordnanceSurvey.ts
+++ b/src/lib/ordnanceSurvey.ts
@@ -45,8 +45,10 @@ export function getOSServiceURL({
   return osServiceURL;
 }
 
-// OS API key must be appended to requests by the proxy endpoint
-// Please see docs: TODO!
+/**
+ * Generate a proxied OS service URL
+ * XXX: OS API key must be appended to requests by the proxy endpoint
+ */
 export function getProxyServiceURL({
   service,
   proxyEndpoint,

--- a/src/lib/ordnanceSurvey.ts
+++ b/src/lib/ordnanceSurvey.ts
@@ -1,0 +1,75 @@
+const OS_DOMAIN = "https://api.os.uk";
+type OSServices = "xyz" | "vectorTile" | "vectorTileStyle";
+type ServiceLookup = Record<OSServices, string>;
+
+// Ordnance Survey sources
+const tileServicePath = `/maps/raster/v1/zxy/Light_3857/{z}/{x}/{y}.png`;
+const vectorTileServicePath = `/maps/vector/v1/vts/tile/{z}/{y}/{x}.pbf`;
+const vectorTileStylePath = `/maps/vector/v1/vts/resources/styles`;
+
+export function constructURL(
+  domain: string,
+  path: string,
+  params: Record<string, string> = {}
+): string {
+  const url = new URL(path, domain);
+  url.search = new URLSearchParams(params).toString();
+  // OL requires that {z}/{x}/{y} are not encoded in order to substitue in real values
+  const openLayersURL = decodeURI(url.href);
+  return openLayersURL;
+}
+
+export function getOSServiceURL(service: OSServices, apiKey: string): string {
+  const serviceURLLookup: ServiceLookup = {
+    xyz: constructURL(OS_DOMAIN, tileServicePath, { key: apiKey }),
+    vectorTile: constructURL(OS_DOMAIN, vectorTileServicePath, {
+      key: apiKey,
+      srs: "3857",
+    }),
+    vectorTileStyle: constructURL(OS_DOMAIN, vectorTileStylePath, {
+      key: apiKey,
+      srs: "3857",
+    }),
+  };
+  return serviceURLLookup[service];
+}
+
+// OS API key must be appended to requests by the proxy endpoint
+// Please see docs: TODO!
+export function getProxyServiceURL(
+  service: OSServices,
+  proxyEndpoint: string
+): string {
+  let { origin: proxyOrigin, pathname: proxyPathname } = new URL(proxyEndpoint);
+  // Remove trailing slash on pathname if present
+  proxyPathname = proxyPathname.replace(/\/$/, "");
+
+  const serviceURLLookup: ServiceLookup = {
+    xyz: constructURL(proxyOrigin, proxyPathname + tileServicePath),
+    vectorTile: constructURL(
+      proxyOrigin,
+      proxyPathname + vectorTileServicePath,
+      { srs: "3857" }
+    ),
+    vectorTileStyle: constructURL(
+      proxyOrigin,
+      proxyPathname + vectorTileStylePath,
+      { srs: "3857" }
+    ),
+  };
+  return serviceURLLookup[service];
+}
+
+export function getServiceURL({
+  service,
+  apiKey,
+  proxyEndpoint,
+}: {
+  service: OSServices;
+  apiKey?: string;
+  proxyEndpoint?: string;
+}): string | undefined {
+  if (proxyEndpoint) return getProxyServiceURL(service, proxyEndpoint);
+  if (apiKey) return getOSServiceURL(service, apiKey);
+  return;
+}

--- a/src/lib/ordnanceSurvey.ts
+++ b/src/lib/ordnanceSurvey.ts
@@ -1,10 +1,12 @@
 const OS_DOMAIN = "https://api.os.uk";
+
 type OSServices =
   | "xyz"
   | "vectorTile"
   | "vectorTileStyle"
   | "places"
   | "features";
+
 interface ServiceOptions {
   service: OSServices;
   apiKey: string;

--- a/src/lib/ordnanceSurvey.ts
+++ b/src/lib/ordnanceSurvey.ts
@@ -65,7 +65,7 @@ export function getProxyServiceURL({
   proxyPathname = proxyPathname.replace(/\/$/, "");
 
   const serviceURLLookup: ServiceLookup = {
-    xyz: constructURL(proxyOrigin, proxyPathname + tileServicePath),
+    xyz: constructURL(proxyOrigin, proxyPathname + tileServicePath, params),
     vectorTile: constructURL(
       proxyOrigin,
       proxyPathname + vectorTileServicePath,
@@ -95,6 +95,6 @@ export function getServiceURL({
     return getProxyServiceURL({ service, proxyEndpoint, params });
   if (apiKey) return getOSServiceURL({ service, apiKey, params });
   throw Error(
-    `Unable to generate URL for OS ${service} API. Either an API key or proxy endpoint must be`
+    `Unable to generate URL for OS ${service} API. Either an API key or proxy endpoint must be supplied`
   );
 }

--- a/src/lib/ordnanceSurvey.ts
+++ b/src/lib/ordnanceSurvey.ts
@@ -1,5 +1,10 @@
 const OS_DOMAIN = "https://api.os.uk";
-type OSServices = "xyz" | "vectorTile" | "vectorTileStyle" | "places";
+type OSServices =
+  | "xyz"
+  | "vectorTile"
+  | "vectorTileStyle"
+  | "places"
+  | "features";
 type ServiceLookup = Record<OSServices, string>;
 interface ServiceOptions {
   service: OSServices;
@@ -13,6 +18,7 @@ const tileServicePath = "/maps/raster/v1/zxy/Light_3857/{z}/{x}/{y}.png";
 const vectorTileServicePath = "/maps/vector/v1/vts/tile/{z}/{y}/{x}.pbf";
 const vectorTileStylePath = "/maps/vector/v1/vts/resources/styles";
 const placesPath = "/search/places/v1/postcode";
+const featuresPath = "/features/v1/wfs";
 
 export function constructURL(
   domain: string,
@@ -42,6 +48,7 @@ export function getOSServiceURL({
       key: apiKey,
     }),
     places: constructURL(OS_DOMAIN, placesPath, { ...params, key: apiKey }),
+    features: constructURL(OS_DOMAIN, featuresPath, { ...params, key: apiKey }),
   };
   return serviceURLLookup[service];
 }
@@ -70,18 +77,24 @@ export function getProxyServiceURL({
       params
     ),
     places: constructURL(proxyOrigin, proxyPathname + placesPath, params),
+    features: constructURL(proxyOrigin, proxyPathname + featuresPath, params),
   };
   return serviceURLLookup[service];
 }
 
+/**
+ * Get either an OS service URL, or a proxied endpoint to an OS service URL
+ */
 export function getServiceURL({
   service,
   apiKey,
   proxyEndpoint,
   params,
-}: ServiceOptions): string | undefined {
+}: ServiceOptions): string {
   if (proxyEndpoint)
     return getProxyServiceURL({ service, proxyEndpoint, params });
   if (apiKey) return getOSServiceURL({ service, apiKey, params });
-  return;
+  throw Error(
+    `Unable to generate URL for OS ${service} API. Either an API key or proxy endpoint must be`
+  );
 }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -11,7 +11,14 @@ export function getShadowRootEl(
   return document.body.querySelector(customEl)?.shadowRoot?.querySelector(el);
 }
 
+export async function setupMap(mapElement: any) {
+  document.body.innerHTML = mapElement;
+  await window.happyDOM.whenAsyncComplete();
+  window.olMap?.dispatchEvent("loadend");
+}
+
 module.exports = {
   getShadowRoot,
   getShadowRootEl,
+  setupMap,
 };


### PR DESCRIPTION
# What does this PR do?
- Support the use of a proxy via the `osProxyEndpoint` property
- This means that we do not need to expose the OS API key when making requests

## How is this achieved?
Before making any requests to the OS, we get the URL from `ordnanceSurvey.getServiceURL()`. 

If the user supplied an OS API key, we'll query the OS API directly and append their key. This is the exact same functionality as currently exists.

If the user supplies an `osProxyEndpoint` value, we'll construct the correct service URL, without an API key. It is the end user's responsibility to host and maintain a suitable service to proxy requests (with the correct authentication) to the OS API.  Ensuring proper access to the proxy endpoint can be done through CORS/CORP on the proxy. The documentation in this repository outlines how this can be achieved.

## Testing
In order to test this, you can run the dev server locally and add the `osProxyEndpoint="https://api.planx.dev/proxy/ordnance-survey"` property to the `my-map` or `address-autocomplete` components. This will also work on the ["Deploy Preview" link](https://deploy-preview-241--oslmap.netlify.app/) generated by the PR.

A number of unit test and service / integration tests have also been added to cover the new functionality, but there's plenty more that could be added to cover all scenarios. I think I've captured the main journeys here but please let me know if you think we need more coverage anywhere.

## Documentation
Pitsby doesn't allow markup or any rich text (even line breaks) in it's descriptions, so linking back to a richer markdown page seemed helpful here.