### PR TITLE
feat: dispatch geojsonChange events in two projections

### DIFF
--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -37,7 +37,13 @@ import {
   pointsSource,
 } from "./snapping";
 import styles from "./styles.scss?inline";
-import { AreaUnitEnum, fitToData, formatArea, hexToRgba } from "./utils";
+import {
+  AreaUnitEnum,
+  fitToData,
+  formatArea,
+  hexToRgba,
+  makeGeoJSON,
+} from "./utils";
 
 type MarkerImageEnum = "circle" | "pin";
 type ResetControlImageEnum = "unicode" | "trash";
@@ -391,12 +397,10 @@ export class MyMap extends LitElement {
         if (sketches.length > 0) {
           const lastSketchGeom = last(sketches)?.getGeometry();
 
-          this.dispatch(
-            "geojsonChange",
-            new GeoJSON().writeFeaturesObject(sketches, {
-              featureProjection: "EPSG:3857",
-            })
-          );
+          this.dispatch("geojsonChange", {
+            webMercator: makeGeoJSON(sketches, "EPSG:3857"),
+            britishNationalGrid: makeGeoJSON(sketches, "EPSG:27700"),
+          });
 
           if (lastSketchGeom && this.drawType === "Polygon") {
             this.dispatch(
@@ -487,12 +491,10 @@ export class MyMap extends LitElement {
           fitToData(map, outlineSource, this.featureBuffer);
 
           // write the geojson representation of the feature or merged features
-          this.dispatch(
-            "featuresGeojsonChange",
-            new GeoJSON().writeFeaturesObject(outlineSource.getFeatures(), {
-              featureProjection: "EPSG:3857",
-            })
-          );
+          this.dispatch("featuresGeojsonChange", {
+            webMercator: makeGeoJSON(outlineSource, "EPSG:3857"),
+            britishNationalGrid: makeGeoJSON(outlineSource, "EPSG:27700"),
+          });
 
           // calculate the total area of the feature or merged features
           const data = outlineSource.getFeatures()[0].getGeometry();

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -398,8 +398,8 @@ export class MyMap extends LitElement {
           const lastSketchGeom = last(sketches)?.getGeometry();
 
           this.dispatch("geojsonChange", {
-            webMercator: makeGeoJSON(sketches, "EPSG:3857"),
-            britishNationalGrid: makeGeoJSON(sketches, "EPSG:27700"),
+            "EPSG:3857": makeGeoJSON(sketches, "EPSG:3857"),
+            "EPSG:27700": makeGeoJSON(sketches, "EPSG:27700"),
           });
 
           if (lastSketchGeom && this.drawType === "Polygon") {
@@ -492,8 +492,8 @@ export class MyMap extends LitElement {
 
           // write the geojson representation of the feature or merged features
           this.dispatch("featuresGeojsonChange", {
-            webMercator: makeGeoJSON(outlineSource, "EPSG:3857"),
-            britishNationalGrid: makeGeoJSON(outlineSource, "EPSG:27700"),
+            "EPSG:3857": makeGeoJSON(outlineSource, "EPSG:3857"),
+            "EPSG:27700": makeGeoJSON(outlineSource, "EPSG:27700"),
           });
 
           // calculate the total area of the feature or merged features

--- a/src/components/my-map/utils.ts
+++ b/src/components/my-map/utils.ts
@@ -1,9 +1,14 @@
 import { asArray, asString } from "ol/color";
 import { buffer } from "ol/extent";
+import { GeoJSON } from "ol/format";
+import { GeoJSONObject } from "ol/format/GeoJSON";
 import Geometry from "ol/geom/Geometry";
+import { Feature } from "ol/index";
 import Map from "ol/Map";
 import { Vector } from "ol/source";
+import VectorSource from "ol/source/Vector";
 import { getArea } from "ol/sphere";
+import { ProjectionEnum } from "./projections";
 
 export type AreaUnitEnum = "m2" | "ha";
 
@@ -54,4 +59,22 @@ export function fitToData(
 export function hexToRgba(hexColor: string, alpha: number) {
   const [r, g, b] = Array.from(asArray(hexColor));
   return asString([r, g, b, alpha]);
+}
+
+/**
+ * Generate a geojson object from a vector source or an array of features
+ * @param source
+ * @param projection
+ * @returns
+ */
+export function makeGeoJSON(
+  source: VectorSource<Geometry> | Feature<Geometry>[],
+  projection: ProjectionEnum
+): GeoJSONObject {
+  return new GeoJSON().writeFeaturesObject(
+    source instanceof VectorSource ? source.getFeatures() : source,
+    {
+      featureProjection: projection,
+    }
+  );
 }


### PR DESCRIPTION
When drawing or selecting features, dispatch their associated geojson change events in two projections: EPSG:3857 (web mercator) & EPSG:27700 (BNG). Previously, we defaulted to only EPSG:3857. 

In PlanX, this will enable us to easily get both the Easting (X), Northing (Y) & longitude, latitude coordinates of a point or polygon without needing to install any extra dependencies to handle further conversions later. 

Will flag as a **break** in our next release, as it changes the data format output by the event! 