### PR TITLE
fix: correctly set geojson writeFeaturesObject options for coordinates projected in EPSG:27700

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
     <div style="display:flex;flex-direction:column;">
       <h1 style="color:red;font-family:Inter,Helvetica,sans-serif;font-size:16px;">*** This is a testing sandbox - these components are unaware of each other! ***</h1>
       <div style="margin-bottom:1em">
-        <my-map zoom="20" maxZoom="23" drawMode drawPointer="dot" id="example-map" showScale disableVectorTiles osProxyEndpoint="https://api.editor.planx.dev/proxy/ordnance-survey" />
+        <my-map zoom="20" maxZoom="23" drawMode drawPointer="dot" id="example-map" showScale osProxyEndpoint="https://api.editor.planx.dev/proxy/ordnance-survey" />
       </div>
       <div style="margin-bottom:1em">
         <postcode-search hintText="Optional hint text shows up here" id="example-postcode" />

--- a/src/components/my-map/utils.ts
+++ b/src/components/my-map/utils.ts
@@ -77,7 +77,6 @@ export function makeGeoJSON(
       ? {
           dataProjection: projection,
           featureProjection: "EPSG:3857",
-          decimals: 0,
         }
       : { featureProjection: projection };
 

--- a/src/components/my-map/utils.ts
+++ b/src/components/my-map/utils.ts
@@ -71,10 +71,18 @@ export function makeGeoJSON(
   source: VectorSource<Geometry> | Feature<Geometry>[],
   projection: ProjectionEnum
 ): GeoJSONObject {
+  // ref https://openlayers.org/en/latest/apidoc/module-ol_format_GeoJSON-GeoJSON.html#writeFeaturesObject
+  const options =
+    projection === "EPSG:27700"
+      ? {
+          dataProjection: projection,
+          featureProjection: "EPSG:3857",
+          decimals: 0,
+        }
+      : { featureProjection: projection };
+
   return new GeoJSON().writeFeaturesObject(
     source instanceof VectorSource ? source.getFeatures() : source,
-    {
-      featureProjection: projection,
-    }
+    options
   );
 }


### PR DESCRIPTION
fixes bug spotted over here: https://github.com/theopensystemslab/planx-new/pull/1377#discussion_r1091647359

geojson change events now logging out "EPSG:27700" coordinates as proper 6-digit positive integers, "EPSG:3857" coordinates were always correct - and remain so!
