### PR TITLE
fix: split on last occurance of council name, not first, in address-autocomplete dropdown options

### DIFF
--- a/src/components/address-autocomplete/index.ts
+++ b/src/components/address-autocomplete/index.ts
@@ -155,9 +155,12 @@ export class AddressAutocomplete extends LitElement {
             .map((address: Address) => {
               // omit the council name and postcode from the display name
               this._options.push(
-                address.LPI.ADDRESS.split(
-                  `, ${address.LPI.ADMINISTRATIVE_AREA}`
-                )[0]
+                address.LPI.ADDRESS.slice(
+                  0,
+                  address.LPI.ADDRESS.lastIndexOf(
+                    `, ${address.LPI.ADMINISTRATIVE_AREA}`
+                  )
+                )
               );
             });
 


### PR DESCRIPTION
Now properly displays full address titles for postcode ME7 1NH
![Screenshot from 2023-03-17 11-26-35](https://user-images.githubusercontent.com/5132349/225879572-86d0c350-2ad5-40cf-ac34-89337f0491a9.png)
