### PR TITLE
ci: configure dependabot to use PNPM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm"
+  - package-ecosystem: "pnpm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
now supported :tada: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#pnpm