### PR TITLE
fix: better dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,15 @@
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "pnpm"
+  - package-ecosystem: "npm" # use this yaml value when package manager is 'pnpm'
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "theopensystemslab/planx"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule: 
+      interval: "weekly"
+    reviewers:
+      - "theopensystemslab/planx"
+      

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,10 @@ updates:
       interval: "weekly"
     reviewers:
       - "theopensystemslab/planx"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule: 
       interval: "weekly"
     reviewers:
       - "theopensystemslab/planx"
-      


### PR DESCRIPTION
- fixes YAML value for PNPM
- adds checks for github action updates too
- better aligns to planx-new configuration https://github.com/theopensystemslab/planx-new/pull/1868

we have a small number of dependencies over here so not limiting number of open PRs from dependabot at any given time.
