### PR TITLE
Allow drawing colour and fill to be customisable

### DIFF
--- a/src/components/my-map/docs/my-map-draw.doc.js
+++ b/src/components/my-map/docs/my-map-draw.doc.js
@@ -29,6 +29,16 @@ module.exports = {
       values: "100 (default)",
     },
     {
+      name: "drawColor",
+      type: "String",
+      values: "#ff0000 (default)",
+    },
+    {
+      name: "drawFillColor",
+      type: "String",
+      values: "rgba(255, 0, 0, 0.1) (default)",
+    },
+    {
       name: "areaUnits",
       type: "String",
       values: "m2 (default), ha",

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -109,6 +109,12 @@ export class MyMap extends LitElement {
   clickFeatures = false;
 
   @property({ type: String })
+  drawColor = "#ff0000";
+
+  @property({ type: String })
+  drawFillColor = "rgba(255, 0, 0, 0.1)";
+
+  @property({ type: String })
   featureColor = "#0000ff";
 
   @property({ type: Boolean })
@@ -282,8 +288,10 @@ export class MyMap extends LitElement {
       this.drawType,
       this.drawPointer,
       this.drawPointColor,
+      this.drawColor,
+      this.drawFillColor,
     );
-    const modify = configureModify(this.drawPointer);
+    const modify = configureModify(this.drawPointer, this.drawColor);
 
     // add custom scale line and north arrow controls to the map
     let scale: ScaleLine;
@@ -396,6 +404,8 @@ export class MyMap extends LitElement {
     const drawingLayer = configureDrawingLayer(
       this.drawType,
       this.drawPointColor,
+      this.drawColor,
+      this.drawFillColor,
     );
     if (this.drawMode) {
       // make sure drawingSource is cleared upfront, even if drawGeojsonData is provided


### PR DESCRIPTION
### Description of change
- In [Bops](https://github.com/unboxed/bops), we want to be able to draw a polygon on the map to visualise a consultation area where we return the addresses in that drawn area. However, this is currently hardcoded in red and to distinguish between the red line boundary and consultation area we preferably want this in a different colour that can be customisable. This PR adds this ability.
- The drawingColor and drawingColorFill defaults to what we usually expect for the red line boundary

Trello ticket:
https://trello.com/c/IQsb3WNF/1908-improve-content-and-layout-for-querying-neighbour-addresses-by-polygon-search

<img width="683" alt="Screenshot 2023-08-30 at 14 03 56" src="https://github.com/theopensystemslab/map/assets/34001723/795649b8-838a-44cc-ab53-eb8f3ae17b42">

