### PR TITLE
Set color of polygon with color set in the geojson feature properties

### DIFF
--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -374,17 +374,22 @@ export class MyMap extends LitElement {
 
     const geojsonLayer = new VectorLayer({
       source: geojsonSource,
-      style: new Style({
-        stroke: new Stroke({
-          color: this.geojsonColor,
-          width: 3,
-        }),
-        fill: new Fill({
-          color: this.geojsonFill
-            ? hexToRgba(this.geojsonColor, 0.2)
-            : hexToRgba(this.geojsonColor, 0),
-        }),
-      }),
+      style: function (this: MyMap, feature: any) {
+        // Retrieve color from feature properties
+        let featureColor = feature.get("color") || this.geojsonColor; // Use the geojsonColor if no color property exists
+
+        return new Style({
+          stroke: new Stroke({
+            color: featureColor,
+            width: 3,
+          }),
+          fill: new Fill({
+            color: this.geojsonFill
+              ? hexToRgba(featureColor, 0.2)
+              : hexToRgba(featureColor, 0),
+          }),
+        });
+      }.bind(this),
     });
 
     map.addLayer(geojsonLayer);


### PR DESCRIPTION
- Default to geojsonColor if the properties color object does not exist
- Can be added to feature i.e. `"properties": {"color": "#e670fc"}`

https://trello.com/c/IQsb3WNF/1908-improve-content-and-layout-for-querying-neighbour-addresses-by-polygon-search

![Screenshot 2023-08-31 at 12 45 59](https://github.com/theopensystemslab/map/assets/34001723/905c29c0-ff5c-427a-a027-30fd035d5e50)
