### PR TITLE
fix: display`drawGeojsonData` vertices in cases of MultiPolygons too

### DIFF
--- a/src/components/my-map/drawing.ts
+++ b/src/components/my-map/drawing.ts
@@ -1,4 +1,4 @@
-import { MultiPoint, Polygon } from "ol/geom";
+import { MultiPoint, MultiPolygon, Polygon } from "ol/geom";
 import { Draw, Modify, Snap } from "ol/interaction";
 import { Vector as VectorLayer } from "ol/layer";
 import { Vector as VectorSource } from "ol/source";
@@ -48,9 +48,12 @@ function polygonVertices(drawColor: string) {
     }),
     geometry: function (feature) {
       const geom = feature.getGeometry();
+      // display the coordinates of the polygon(s)
       if (geom instanceof Polygon) {
-        // return the coordinates of the drawn polygon
         const coordinates = geom.getCoordinates()[0];
+        return new MultiPoint(coordinates);
+      } else if (geom instanceof MultiPolygon) {
+        const coordinates = geom.getCoordinates().flat(2);
         return new MultiPoint(coordinates);
       } else {
         return;


### PR DESCRIPTION
Addresses feedback raised around displaying Title boundaries from Land Registry here https://github.com/theopensystemslab/planx-new/pull/2561

![Screenshot from 2023-12-13 15-03-53](https://github.com/theopensystemslab/map/assets/5132349/af72df77-9495-4aac-a888-fa0d65ea9c95)
![Screenshot from 2023-12-13 15-04-27](https://github.com/theopensystemslab/map/assets/5132349/563d5f0f-4f81-4924-ae0d-278f35d02f2d)
