### PR TITLE
fix: usability improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
   <script>
     // --- MAP --- //
     const map = document.querySelector("my-map");
-    map.geojsonDataCopyright = `<a href="https://www.planning.data.gov.uk/dataset/title-boundary" target="_blank" style="color:#0010A4;">Title boundary</a> subject to Crown copyright and database rights ${new Date().getFullYear()} OS (0)100026316`;
+    map.geojsonDataCopyright = `<a href="https://www.planning.data.gov.uk/dataset/title-boundary" target="_blank">Title boundary</a> subject to Crown copyright and database rights ${new Date().getFullYear()} OS (0)100026316`;
     map.clipGeojsonData = {
       "type": "Feature",
       "geometry": {

--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
   <script>
     // --- MAP --- //
     const map = document.querySelector("my-map");
+    map.geojsonDataCopyright = `<a href="https://www.planning.data.gov.uk/dataset/title-boundary" target="_blank" style="color:#0010A4;">Title boundary</a> subject to Crown copyright and database rights ${new Date().getFullYear()} OS (0)100026316`;
     map.clipGeojsonData = {
       "type": "Feature",
       "geometry": {

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -364,22 +364,15 @@ export class MyMap extends LitElement {
       node.setAttribute("aria-label", node.getAttribute("title") || ""),
     );
 
-    // Apply tabindexes to OL Controls & Attribution links for accessibility (container div has starting tabindex="1")
-    const controlsLength = olControls?.length;
-    olControls?.forEach((node, i) =>
-      // if `collapseAttributions` is set, ensure attributions control button is last, else follow top-down order
-      node.title === "Attributions"
-        ? (node.tabIndex = 2 + controlsLength)
-        : (node.tabIndex = i + 2),
+    // Re-order overlay elements so that OL Attribution is final element
+    //   making OL Controls first in natural tab order for accessibility
+    const olAttribution = this.renderRoot?.querySelector(
+      ".ol-attribution",
+    ) as Node;
+    const olOverlay = this.renderRoot?.querySelector(
+      ".ol-overlaycontainer-stopevent",
     );
-
-    if (!this.collapseAttributions) {
-      const olAttributionLinks: NodeListOf<HTMLAnchorElement> | undefined =
-        this.renderRoot?.querySelectorAll(".ol-attribution a");
-      olAttributionLinks?.forEach(
-        (node, i) => (node.tabIndex = i + 2 + controlsLength),
-      );
-    }
+    olOverlay?.append(olAttribution);
 
     // define cursors for dragging/panning and moving
     map.on("pointerdrag", () => {
@@ -651,7 +644,7 @@ export class MyMap extends LitElement {
       <div
         id="${this.id}"
         class="map"
-        tabindex="${this.staticMode && !this.collapseAttributions ? -1 : 1}"
+        tabindex="${this.staticMode && !this.collapseAttributions ? -1 : 0}"
       />`;
   }
 

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -309,22 +309,6 @@ export class MyMap extends LitElement {
     );
     const modify = configureModify(this.drawPointer, this.drawColor);
 
-    // add custom scale line and north arrow controls to the map
-    let scale: ScaleLine;
-    if (this.showNorthArrow) {
-      map.addControl(northArrowControl());
-    }
-
-    if (this.showScale) {
-      scale = scaleControl(this.useScaleBarStyle);
-      map.addControl(scale);
-    }
-
-    if (this.showPrint) {
-      const printControl = new PrintControl({ map });
-      map.addControl(printControl);
-    }
-
     // add a custom 'reset' control to the map
     const handleReset = () => {
       if (this.showFeaturesAtPoint) {
@@ -357,11 +341,37 @@ export class MyMap extends LitElement {
       map.addControl(resetControl(handleReset, this.resetControlImage));
     }
 
+    // add custom scale line and north arrow controls to the map
+    let scale: ScaleLine;
+    if (this.showNorthArrow) {
+      map.addControl(northArrowControl());
+    }
+
+    if (this.showScale) {
+      scale = scaleControl(this.useScaleBarStyle);
+      map.addControl(scale);
+    }
+
+    if (this.showPrint) {
+      const printControl = new PrintControl({ map });
+      map.addControl(printControl);
+    }
+
     // Apply aria-labels to OL Controls for accessibility
     const olControls: NodeListOf<HTMLButtonElement> | undefined =
       this.renderRoot?.querySelectorAll(".ol-control button");
     olControls?.forEach((node) =>
       node.setAttribute("aria-label", node.getAttribute("title") || ""),
+    );
+
+    // Apply tabindexes to OL Controls & Attribution links for accessibility (container div has starting tabindex="1")
+    const controlsLength = olControls?.length;
+    olControls?.forEach((node, i) => (node.tabIndex = i + 2));
+
+    const olAttributionLinks: NodeListOf<HTMLAnchorElement> | undefined =
+      this.renderRoot?.querySelectorAll(".ol-attribution a");
+    olAttributionLinks?.forEach(
+      (node, i) => (node.tabIndex = i + 2 + controlsLength),
     );
 
     // define cursors for dragging/panning and moving
@@ -631,7 +641,11 @@ export class MyMap extends LitElement {
   render() {
     return html`<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
       <link rel="stylesheet" href="https://cdn.skypack.dev/ol@^6.6.1/ol.css" />
-      <div id="${this.id}" class="map" tabindex="0" />`;
+      <div
+        id="${this.id}"
+        class="map"
+        tabindex="${this.staticMode ? -1 : 1}"
+      />`;
   }
 
   // unmount the map

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -651,7 +651,7 @@ export class MyMap extends LitElement {
       <div
         id="${this.id}"
         class="map"
-        tabindex="${this.staticMode ? -1 : 1}"
+        tabindex="${this.staticMode && !this.collapseAttributions ? -1 : 1}"
       />`;
   }
 

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -366,13 +366,20 @@ export class MyMap extends LitElement {
 
     // Apply tabindexes to OL Controls & Attribution links for accessibility (container div has starting tabindex="1")
     const controlsLength = olControls?.length;
-    olControls?.forEach((node, i) => (node.tabIndex = i + 2));
-
-    const olAttributionLinks: NodeListOf<HTMLAnchorElement> | undefined =
-      this.renderRoot?.querySelectorAll(".ol-attribution a");
-    olAttributionLinks?.forEach(
-      (node, i) => (node.tabIndex = i + 2 + controlsLength),
+    olControls?.forEach((node, i) =>
+      // if `collapseAttributions` is set, ensure attributions control button is last, else follow top-down order
+      node.title === "Attributions"
+        ? (node.tabIndex = 2 + controlsLength)
+        : (node.tabIndex = i + 2),
     );
+
+    if (!this.collapseAttributions) {
+      const olAttributionLinks: NodeListOf<HTMLAnchorElement> | undefined =
+        this.renderRoot?.querySelectorAll(".ol-attribution a");
+      olAttributionLinks?.forEach(
+        (node, i) => (node.tabIndex = i + 2 + controlsLength),
+      );
+    }
 
     // define cursors for dragging/panning and moving
     map.on("pointerdrag", () => {

--- a/src/components/my-map/main.test.ts
+++ b/src/components/my-map/main.test.ts
@@ -49,6 +49,15 @@ describe("Keyboard navigation of map container, controls and attribution links",
     expect(map).toBeTruthy;
     expect(map?.getAttribute("tabindex")).toEqual("-1");
   });
+
+  it("should keep map container in tab order if attributions are collapsed", async () => {
+    await setupMap(
+      `<my-map id="map-vitest" disableVectorTiles staticMode collapseAttributions />`,
+    );
+    const map = getShadowRoot("my-map")?.getElementById("map-vitest");
+    expect(map).toBeTruthy;
+    expect(map?.getAttribute("tabindex")).toEqual("1");
+  });
 });
 
 describe("Snap points loading behaviour", () => {

--- a/src/components/my-map/main.test.ts
+++ b/src/components/my-map/main.test.ts
@@ -40,7 +40,7 @@ describe("Keyboard navigation of map container, controls and attribution links",
     await setupMap(`<my-map id="map-vitest" disableVectorTiles />`);
     const map = getShadowRoot("my-map")?.getElementById("map-vitest");
     expect(map).toBeTruthy;
-    expect(map?.getAttribute("tabindex")).toEqual("1");
+    expect(map?.getAttribute("tabindex")).toEqual("0");
   });
 
   it("should omit map container from tab order if not interactive", async () => {
@@ -56,7 +56,7 @@ describe("Keyboard navigation of map container, controls and attribution links",
     );
     const map = getShadowRoot("my-map")?.getElementById("map-vitest");
     expect(map).toBeTruthy;
-    expect(map?.getAttribute("tabindex")).toEqual("1");
+    expect(map?.getAttribute("tabindex")).toEqual("0");
   });
 });
 

--- a/src/components/my-map/main.test.ts
+++ b/src/components/my-map/main.test.ts
@@ -23,7 +23,7 @@ test("olMap is added to the global window for tests", async () => {
 describe("MyMap on initial render with OSM basemap", async () => {
   beforeEach(
     () => setupMap('<my-map id="map-vitest" disableVectorTiles />'),
-    2500
+    2500,
   );
 
   it("should render a custom element with a shadow root", () => {
@@ -33,11 +33,21 @@ describe("MyMap on initial render with OSM basemap", async () => {
     const mapShadowRoot = getShadowRoot("my-map");
     expect(mapShadowRoot).toBeTruthy;
   });
+});
 
-  it("should be keyboard navigable", () => {
+describe("Keyboard navigation of map container, controls and attribution links", () => {
+  it("map container should be keyboard navigable by default", async () => {
+    await setupMap(`<my-map id="map-vitest" disableVectorTiles />`);
     const map = getShadowRoot("my-map")?.getElementById("map-vitest");
     expect(map).toBeTruthy;
-    expect(map?.getAttribute("tabindex")).toEqual("0");
+    expect(map?.getAttribute("tabindex")).toEqual("1");
+  });
+
+  it("should omit map container from tab order if not interactive", async () => {
+    await setupMap(`<my-map id="map-vitest" disableVectorTiles staticMode />`);
+    const map = getShadowRoot("my-map")?.getElementById("map-vitest");
+    expect(map).toBeTruthy;
+    expect(map?.getAttribute("tabindex")).toEqual("-1");
   });
 });
 
@@ -47,7 +57,7 @@ describe("Snap points loading behaviour", () => {
 
   const getSnapSpy: MockInstance = vi.spyOn(
     snapping,
-    "getSnapPointsFromVectorTiles"
+    "getSnapPointsFromVectorTiles",
   );
   afterEach(() => {
     vi.resetAllMocks();

--- a/src/components/my-map/styles.scss
+++ b/src/components/my-map/styles.scss
@@ -15,7 +15,7 @@
 }
 
 .map:focus {
-  outline: #ffdd00 solid 0.25em;
+  outline: #ffdd00 solid 0.25em; // GOV.UK yellow
 }
 
 .ol-control button {
@@ -29,6 +29,10 @@
 
 .ol-control button:hover {
   background-color: rgba(44, 44, 44, 0.85) !important;
+}
+
+.ol-control button:focus {
+  outline: #ffdd00 solid 0.15em; // GOV.UK yellow
 }
 
 .ol-scale-line {
@@ -97,4 +101,13 @@
 
 .ol-attribution li {
   display: list-item;
+}
+
+.ol-attribution a {
+  color: #0010a4; // Planx blue
+}
+
+.ol-attribution a:focus {
+  color: black;
+  background-color: #ffdd00; // GOV.UK yellow
 }

--- a/src/components/my-map/styles.scss
+++ b/src/components/my-map/styles.scss
@@ -1,3 +1,7 @@
+$gov-uk-yellow: #ffdd00;
+$planx-blue: #0010a4;
+$planx-dark-grey: #2c2c2c;
+
 // default map size, can be overwritten with CSS
 :host {
   display: block;
@@ -15,12 +19,12 @@
 }
 
 .map:focus {
-  outline: #ffdd00 solid 0.25em; // GOV.UK yellow
+  outline: $gov-uk-yellow solid 0.25em;
 }
 
 .ol-control button {
   border-radius: 0 !important;
-  background-color: #2c2c2c !important;
+  background-color: $planx-dark-grey !important;
   cursor: pointer;
   min-width: 44px;
   min-height: 44px;
@@ -32,7 +36,7 @@
 }
 
 .ol-control button:focus {
-  outline: #ffdd00 solid 0.15em; // GOV.UK yellow
+  outline: $gov-uk-yellow solid 0.15em;
 }
 
 .ol-scale-line {
@@ -40,9 +44,9 @@
 }
 
 .ol-scale-line-inner {
-  border: 0.2em solid #2c2c2c;
+  border: 0.2em solid $planx-dark-grey;
   border-top: none;
-  color: #2c2c2c;
+  color: $planx-dark-grey;
   font-size: 1em;
   font-family: inherit;
 }
@@ -104,10 +108,10 @@
 }
 
 .ol-attribution a {
-  color: #0010a4; // Planx blue
+  color: $planx-blue;
 }
 
 .ol-attribution a:focus {
   color: black;
-  background-color: #ffdd00; // GOV.UK yellow
+  background-color: $gov-uk-yellow;
 }


### PR DESCRIPTION
A number of styling tweaks based on feedback from Planx's most recent accessibility audit: 
- [x] Control button focus color is now GOV.UK yellow for stronger contrast
- [x] Attribution link focus color is now GOV.UK yellow for stronger contrast
- [x] Tab order of control buttons and attribution links is now top to bottom, left to right
- [x] Tab index is omitted from map altogether in cases where `staticMode` is set and attributions are _not_ collapsed

![chrome-capture-2024-3-4](https://github.com/theopensystemslab/map/assets/5132349/6512ad52-e423-4999-a5ca-5aaf0c0f35d7)

Future scope / followup:
- [ ] How to set `aria-label` on canvas element in shadow dom, _not_ container div rendered by Lit
- [ ] Snap points color needs stronger contrast (another basemap altogether?)