### PR TITLE
feat: add support for drawing and modifying `Circle` geometry types

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
     <h1 style="color:red;font-size:16px;">*** This is a testing sandbox - these components are unaware of each other!
       ***</h1>
     <div style="margin-bottom:1em">
-      <my-map zoom="20" maxZoom="23" id="example-map" drawMode useScaleBarStyle showScale showNorthArrow showPrint
+      <my-map zoom="20" maxZoom="23" id="example-map" drawMode drawType="Circle" useScaleBarStyle showScale showNorthArrow showPrint
         osProxyEndpoint="https://api.editor.planx.dev/proxy/ordnance-survey" ariaLabelOlFixedOverlay="Interactive example map" />
     </div>
     <div style="margin-bottom:1em">

--- a/src/components/my-map/drawing.ts
+++ b/src/components/my-map/drawing.ts
@@ -1,38 +1,41 @@
 import { MultiPoint, MultiPolygon, Polygon } from "ol/geom";
+import { Type } from "ol/geom/Geometry";
 import { Draw, Modify, Snap } from "ol/interaction";
 import { Vector as VectorLayer } from "ol/layer";
 import { Vector as VectorSource } from "ol/source";
 import { Circle, Fill, RegularShape, Stroke, Style } from "ol/style";
 import CircleStyle from "ol/style/Circle";
-import { StyleLike } from "ol/style/Style";
 import { pointsSource } from "./snapping";
 
-export type DrawTypeEnum = "Polygon" | "Point"; // ref https://openlayers.org/en/latest/apidoc/module-ol_geom_Geometry.html#~Type
+export type DrawTypeEnum = Extract<Type, "Polygon" | "Point" | "Circle">;
 export type DrawPointerEnum = "crosshair" | "dot";
 
-// drawPointer styles
-function crosshair(drawColor: string) {
-  return new RegularShape({
-    stroke: new Stroke({
-      color: drawColor,
-      width: 2,
-    }),
-    points: 4, // crosshair aka star
-    radius: 15, // outer radius
-    radius2: 1, // inner radius
-  });
+function configureDrawPointerImage(
+  drawPointer: DrawPointerEnum,
+  drawColor: string,
+) {
+  switch (drawPointer) {
+    case "crosshair":
+      return new RegularShape({
+        stroke: new Stroke({
+          color: drawColor,
+          width: 2,
+        }),
+        points: 4, // crosshair aka star
+        radius: 15, // outer radius
+        radius2: 1, // inner radius
+      });
+    case "dot":
+      return new CircleStyle({
+        radius: 6,
+        fill: new Fill({
+          color: drawColor,
+        }),
+      });
+  }
 }
 
-function dot(drawColor: string) {
-  return new CircleStyle({
-    radius: 6,
-    fill: new Fill({
-      color: drawColor,
-    }),
-  });
-}
-
-function polygonVertices(drawColor: string) {
+function getVertices(drawColor: string) {
   return new Style({
     image: new RegularShape({
       fill: new Fill({
@@ -48,7 +51,6 @@ function polygonVertices(drawColor: string) {
     }),
     geometry: function (feature) {
       const geom = feature.getGeometry();
-      // display the coordinates of the polygon(s)
       if (geom instanceof Polygon) {
         const coordinates = geom.getCoordinates()[0];
         return new MultiPoint(coordinates);
@@ -62,60 +64,34 @@ function polygonVertices(drawColor: string) {
   });
 }
 
-function boundaryLayerStyle(
-  drawColor: string,
-  drawColorFill: string,
-): StyleLike {
-  return [
-    new Style({
-      fill: new Fill({
-        color: drawColorFill,
-      }),
-      stroke: new Stroke({
-        color: drawColor,
-        width: 3,
-      }),
-    }),
-    polygonVertices(drawColor),
-  ];
-}
-
-function configureBoundaryDrawStyle(
-  pointerStyle: DrawPointerEnum,
+function configureDrawingLayerStyle(
+  drawType: DrawTypeEnum,
   drawColor: string,
   drawFillColor: string,
+  pointColor: string,
 ) {
-  return new Style({
-    stroke: configureDashedStroke(drawColor),
-    fill: new Fill({
-      color: drawFillColor,
-    }),
-    image: pointerStyle === "crosshair" ? crosshair(drawColor) : dot(drawColor),
-  });
-}
-
-function configureDashedStroke(drawColor: string) {
-  return new Stroke({
-    color: drawColor,
-    width: 3,
-    lineDash: [2, 8],
-  });
-}
-
-// feature style: single point
-function configurePointLayerStyle(pointColor: string) {
-  return new Style({
-    image: new Circle({
-      radius: 9,
-      fill: new Fill({ color: pointColor }),
-    }),
-  });
-}
-
-function configurePointDrawStyle(pointColor: string) {
-  return new Style({
-    fill: new Fill({ color: pointColor }),
-  });
+  switch (drawType) {
+    case "Point":
+      return new Style({
+        image: new Circle({
+          radius: 9,
+          fill: new Fill({ color: pointColor }),
+        }),
+      });
+    default:
+      return [
+        new Style({
+          fill: new Fill({
+            color: drawFillColor,
+          }),
+          stroke: new Stroke({
+            color: drawColor,
+            width: 3,
+          }),
+        }),
+        getVertices(drawColor),
+      ];
+  }
 }
 
 export const drawingSource = new VectorSource();
@@ -128,17 +104,45 @@ export function configureDrawingLayer(
 ) {
   return new VectorLayer({
     source: drawingSource,
-    style:
-      drawType === "Polygon"
-        ? boundaryLayerStyle(drawColor, drawFillColor)
-        : configurePointLayerStyle(pointColor),
+    style: configureDrawingLayerStyle(
+      drawType,
+      drawColor,
+      drawFillColor,
+      pointColor,
+    ),
   });
 }
 
-// configure the key openlayers interactions
+function configureDrawInteractionStyle(
+  drawType: DrawTypeEnum,
+  drawPointer: DrawPointerEnum,
+  drawColor: string,
+  drawFillColor: string,
+  pointColor: string,
+) {
+  switch (drawType) {
+    case "Point":
+      return new Style({
+        fill: new Fill({ color: pointColor }),
+      });
+    default:
+      return new Style({
+        stroke: new Stroke({
+          color: drawColor,
+          width: 3,
+          lineDash: [2, 8],
+        }),
+        fill: new Fill({
+          color: drawFillColor,
+        }),
+        image: configureDrawPointerImage(drawPointer, drawColor),
+      });
+  }
+}
+
 export function configureDraw(
   drawType: DrawTypeEnum,
-  pointerStyle: DrawPointerEnum,
+  drawPointer: DrawPointerEnum,
   pointColor: string,
   drawColor: string,
   drawFillColor: string,
@@ -146,10 +150,13 @@ export function configureDraw(
   return new Draw({
     source: drawingSource,
     type: drawType,
-    style:
-      drawType === "Polygon"
-        ? configureBoundaryDrawStyle(pointerStyle, drawColor, drawFillColor)
-        : configurePointDrawStyle(pointColor),
+    style: configureDrawInteractionStyle(
+      drawType,
+      drawPointer,
+      drawColor,
+      drawFillColor,
+      pointColor,
+    ),
   });
 }
 
@@ -159,14 +166,13 @@ export const snap = new Snap({
 });
 
 export function configureModify(
-  pointerStyle: DrawPointerEnum,
+  drawPointer: DrawPointerEnum,
   drawColor: string,
 ) {
   return new Modify({
     source: drawingSource,
     style: new Style({
-      image:
-        pointerStyle === "crosshair" ? crosshair(drawColor) : dot(drawColor),
+      image: configureDrawPointerImage(drawPointer, drawColor),
     }),
   });
 }


### PR DESCRIPTION
Replaces #464 - let's introduce one new shape at a time ! 

![chrome-capture-2024-6-26](https://github.com/user-attachments/assets/7b22e2d5-a4ec-4579-b4ef-be8d489b1b62)

**Changes:**
- `drawType` prop now supports `Circle` in addition to original `Polygon` (still default) and `Point`
  - We anticipate using this in Planx to mark the location of trees
- Supports modifying the circle simply by grabbing any edge and dragging - there will _not_ be visible vertice cues like we have with polygon modify
- Refactors styling helper methods and swaps out all `drawType` ternaries to switch statements, which will scale a lot nicer as we support more draw types going forward (for now, the circle is sharing stroke and fill styles with the polygon)

**Followup PRs:**
- Dispatch geojson & area change events when `drawType="Circle"` 
  - "Circle" is not a supported GeoJSON type, so we'll transform it to a polygon first to dispatch - 
  - We should be able to use an OL helper method like [`fromCircle()`](https://openlayers.org/en/latest/apidoc/module-ol_geom_Polygon.html#.fromCircle) here, but getting some type errors (eg our drawn circle is type "SimplifiedCircle" geometry rather than true "Circle" that will be easier to troubleshoot in a separate followup!)