### PR TITLE
break: condense and deprecate redundant styling-related props

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
     <h1 style="color:red;font-size:16px;">*** This is a testing sandbox - these components are unaware of each other!
       ***</h1>
     <div style="margin-bottom:1em">
-      <my-map zoom="20" maxZoom="23" id="example-map" drawMode drawType="Circle" useScaleBarStyle showScale showNorthArrow showPrint
+      <my-map zoom="20" maxZoom="23" id="example-map" drawMode drawType="Polygon" useScaleBarStyle showScale showNorthArrow showPrint
         osProxyEndpoint="https://api.editor.planx.dev/proxy/ordnance-survey" ariaLabelOlFixedOverlay="Interactive example map" />
     </div>
     <div style="margin-bottom:1em">

--- a/src/components/my-map/drawing.ts
+++ b/src/components/my-map/drawing.ts
@@ -1,3 +1,4 @@
+import { FeatureLike } from "ol/Feature";
 import { MultiPoint, MultiPolygon, Polygon } from "ol/geom";
 import { Type } from "ol/geom/Geometry";
 import { Draw, Modify, Snap } from "ol/interaction";
@@ -6,19 +7,10 @@ import { Vector as VectorSource } from "ol/source";
 import { Circle, Fill, RegularShape, Stroke, Style, Text } from "ol/style";
 import CircleStyle from "ol/style/Circle";
 import { pointsSource } from "./snapping";
-import { FeatureLike } from "ol/Feature";
+import { hexToRgba } from "./utils";
 
 export type DrawTypeEnum = Extract<Type, "Polygon" | "Point" | "Circle">;
 export type DrawPointerEnum = "crosshair" | "dot";
-
-function getFillFromColor(drawColor: string) {
-  if (drawColor.startsWith("#")) {
-    // 10% opacity
-    return "#1A" + drawColor.substring(1);
-  } else {
-    return drawColor;
-  }
-}
 
 function configureDrawPointerImage(
   drawPointer: DrawPointerEnum,
@@ -77,7 +69,7 @@ function getVertices(drawColor: string) {
 function styleFeatureLabels(drawType: DrawTypeEnum, feature: FeatureLike) {
   return new Text({
     text: feature.get("label"),
-    font: "50px inherit",
+    font: "80px inherit",
     placement: drawType === "Point" ? "line" : "point", // "point" placement is center point of polygon
     fill: new Fill({
       color: "#000",
@@ -108,7 +100,7 @@ function configureDrawingLayerStyle(
       return [
         new Style({
           fill: new Fill({
-            color: getFillFromColor(drawColor),
+            color: hexToRgba(drawColor, 0.2),
           }),
           stroke: new Stroke({
             color: drawColor,
@@ -141,8 +133,6 @@ function configureDrawInteractionStyle(
   drawPointer: DrawPointerEnum,
   drawColor: string,
 ) {
-  console.log("here", getFillFromColor(drawColor));
-
   switch (drawType) {
     case "Point":
       return new Style({
@@ -156,7 +146,7 @@ function configureDrawInteractionStyle(
           lineDash: [2, 8],
         }),
         fill: new Fill({
-          color: getFillFromColor(drawColor),
+          color: hexToRgba(drawColor, 0.2),
         }),
         image: configureDrawPointerImage(drawPointer, drawColor),
       });

--- a/src/components/my-map/drawing.ts
+++ b/src/components/my-map/drawing.ts
@@ -10,6 +10,15 @@ import { pointsSource } from "./snapping";
 export type DrawTypeEnum = Extract<Type, "Polygon" | "Point" | "Circle">;
 export type DrawPointerEnum = "crosshair" | "dot";
 
+function getFillFromColor(drawColor: string) {
+  if (drawColor.startsWith("#")) {
+    // 10% opacity
+    return "#1A" + drawColor.substring(1);
+  } else {
+    return drawColor;
+  }
+}
+
 function configureDrawPointerImage(
   drawPointer: DrawPointerEnum,
   drawColor: string,
@@ -64,25 +73,20 @@ function getVertices(drawColor: string) {
   });
 }
 
-function configureDrawingLayerStyle(
-  drawType: DrawTypeEnum,
-  drawColor: string,
-  drawFillColor: string,
-  pointColor: string,
-) {
+function configureDrawingLayerStyle(drawType: DrawTypeEnum, drawColor: string) {
   switch (drawType) {
     case "Point":
       return new Style({
         image: new Circle({
           radius: 9,
-          fill: new Fill({ color: pointColor }),
+          fill: new Fill({ color: drawColor }),
         }),
       });
     default:
       return [
         new Style({
           fill: new Fill({
-            color: drawFillColor,
+            color: getFillFromColor(drawColor),
           }),
           stroke: new Stroke({
             color: drawColor,
@@ -98,18 +102,11 @@ export const drawingSource = new VectorSource();
 
 export function configureDrawingLayer(
   drawType: DrawTypeEnum,
-  pointColor: string,
   drawColor: string,
-  drawFillColor: string,
 ) {
   return new VectorLayer({
     source: drawingSource,
-    style: configureDrawingLayerStyle(
-      drawType,
-      drawColor,
-      drawFillColor,
-      pointColor,
-    ),
+    style: configureDrawingLayerStyle(drawType, drawColor),
   });
 }
 
@@ -117,13 +114,13 @@ function configureDrawInteractionStyle(
   drawType: DrawTypeEnum,
   drawPointer: DrawPointerEnum,
   drawColor: string,
-  drawFillColor: string,
-  pointColor: string,
 ) {
+  console.log("here", getFillFromColor(drawColor));
+
   switch (drawType) {
     case "Point":
       return new Style({
-        fill: new Fill({ color: pointColor }),
+        fill: new Fill({ color: drawColor }),
       });
     default:
       return new Style({
@@ -133,7 +130,7 @@ function configureDrawInteractionStyle(
           lineDash: [2, 8],
         }),
         fill: new Fill({
-          color: drawFillColor,
+          color: getFillFromColor(drawColor),
         }),
         image: configureDrawPointerImage(drawPointer, drawColor),
       });
@@ -143,20 +140,12 @@ function configureDrawInteractionStyle(
 export function configureDraw(
   drawType: DrawTypeEnum,
   drawPointer: DrawPointerEnum,
-  pointColor: string,
   drawColor: string,
-  drawFillColor: string,
 ) {
   return new Draw({
     source: drawingSource,
     type: drawType,
-    style: configureDrawInteractionStyle(
-      drawType,
-      drawPointer,
-      drawColor,
-      drawFillColor,
-      pointColor,
-    ),
+    style: configureDrawInteractionStyle(drawType, drawPointer, drawColor),
   });
 }
 

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -88,6 +88,9 @@ export class MyMap extends LitElement {
   @property({ type: String })
   drawType: DrawTypeEnum = "Polygon";
 
+  /**
+   * @deprecated - please set `drawColor`
+   */
   @property({ type: String })
   drawPointColor = "#2c2c2c";
 
@@ -115,6 +118,9 @@ export class MyMap extends LitElement {
   @property({ type: String })
   drawColor = "#ff0000";
 
+  /**
+   * @deprecated - please set `drawColor` and fill will be automatically inferred using 10% opacity
+   */
   @property({ type: String })
   drawFillColor = "rgba(255, 0, 0, 0.1)";
 
@@ -303,13 +309,7 @@ export class MyMap extends LitElement {
     window.olMap = import.meta.env.VITEST ? this.map : undefined;
 
     // make configurable interactions available
-    const draw = configureDraw(
-      this.drawType,
-      this.drawPointer,
-      this.drawPointColor,
-      this.drawColor,
-      this.drawFillColor,
-    );
+    const draw = configureDraw(this.drawType, this.drawPointer, this.drawColor);
     const modify = configureModify(this.drawPointer, this.drawColor);
 
     // add a custom 'reset' control to the map
@@ -449,12 +449,7 @@ export class MyMap extends LitElement {
     }
 
     // draw interactions
-    const drawingLayer = configureDrawingLayer(
-      this.drawType,
-      this.drawPointColor,
-      this.drawColor,
-      this.drawFillColor,
-    );
+    const drawingLayer = configureDrawingLayer(this.drawType, this.drawColor);
     if (this.drawMode) {
       // make sure drawingSource is cleared upfront, even if drawGeojsonData is provided
       drawingSource.clear();

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -110,9 +110,6 @@ export class MyMap extends LitElement {
   drawPointer: DrawPointerEnum = "crosshair";
 
   @property({ type: Boolean })
-  showFeaturesAtPoint = false;
-
-  @property({ type: Boolean })
   clickFeatures = false;
 
   @property({ type: String })
@@ -124,20 +121,23 @@ export class MyMap extends LitElement {
   @property({ type: String })
   drawFillColor = "rgba(255, 0, 0, 0.1)";
 
+  @property({ type: Boolean })
+  showFeaturesAtPoint = false;
+
   @property({ type: String })
   featureColor = "#0000ff";
 
   @property({ type: Boolean })
   featureFill = false;
 
+  /**
+   * @deprecated
+   */
   @property({ type: Boolean })
   featureBorderNone = false;
 
   @property({ type: Number })
   featureBuffer = 40;
-
-  @property({ type: Boolean })
-  showGeojsonDataMarkers = false;
 
   @property({ type: Boolean })
   showCentreMarker = false;
@@ -159,6 +159,9 @@ export class MyMap extends LitElement {
     type: "FeatureCollection",
     features: [],
   };
+
+  @property({ type: Boolean })
+  showGeojsonDataMarkers = false;
 
   @property({ type: String })
   geojsonDataCopyright = "";
@@ -418,9 +421,8 @@ export class MyMap extends LitElement {
     const geojsonLayer = new VectorLayer({
       source: geojsonSource,
       style: function (this: MyMap, feature: any) {
-        // Retrieve color from feature properties
-        let featureColor = feature.get("color") || this.geojsonColor; // Use the geojsonColor if no color property exists
-
+        // Read color from geojson feature `properties` if set or fallback to prop
+        let featureColor = feature.get("color") || this.geojsonColor;
         return new Style({
           stroke: new Stroke({
             color: featureColor,
@@ -575,7 +577,6 @@ export class MyMap extends LitElement {
       const outlineLayer = makeFeatureLayer(
         this.featureColor,
         this.featureFill,
-        this.featureBorderNone,
       );
       map.addLayer(outlineLayer);
 

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -89,7 +89,7 @@ export class MyMap extends LitElement {
   drawType: DrawTypeEnum = "Polygon";
 
   /**
-   * @deprecated - please set `drawColor`
+   * @deprecated - please set `drawColor` regardless of `drawType`
    */
   @property({ type: String })
   drawPointColor = "#2c2c2c";
@@ -116,7 +116,7 @@ export class MyMap extends LitElement {
   drawColor = "#ff0000";
 
   /**
-   * @deprecated - please set `drawColor` and fill will be automatically inferred using 10% opacity
+   * @deprecated - please set `drawColor` and fill will be automatically inferred using 20% opacity
    */
   @property({ type: String })
   drawFillColor = "rgba(255, 0, 0, 0.1)";

--- a/src/components/my-map/os-features.ts
+++ b/src/components/my-map/os-features.ts
@@ -12,20 +12,14 @@ const featureSource = new VectorSource();
 
 export const outlineSource = new VectorSource();
 
-export function makeFeatureLayer(
-  color: string,
-  featureFill: boolean,
-  borderNone: boolean
-) {
+export function makeFeatureLayer(color: string, featureFill: boolean) {
   return new VectorLayer({
     source: outlineSource,
     style: new Style({
-      stroke: borderNone
-        ? undefined
-        : new Stroke({
-            width: 3,
-            color: color,
-          }),
+      stroke: new Stroke({
+        width: 3,
+        color: color,
+      }),
       fill: new Fill({
         color: featureFill ? hexToRgba(color, 0.2) : hexToRgba(color, 0),
       }),
@@ -45,7 +39,7 @@ export function getFeaturesAtPoint(
   coord: Array<number>,
   apiKey: any,
   proxyEndpoint: string,
-  supportClickFeatures: boolean
+  supportClickFeatures: boolean,
 ) {
   const xml = `
     <ogc:Filter>
@@ -91,7 +85,7 @@ export function getFeaturesAtPoint(
         validKeys = ["TOID", "DescriptiveGroup"];
 
       Object.keys(properties).forEach(
-        (key) => validKeys.includes(key) || delete properties[key]
+        (key) => validKeys.includes(key) || delete properties[key],
       );
 
       const geojson = new GeoJSON();
@@ -131,8 +125,8 @@ export function getFeaturesAtPoint(
           featureSource.getFeatures().reduce((acc: any, curr) => {
             const toMerge = geojson.writeFeatureObject(curr).geometry;
             return acc ? union(acc, toMerge) : toMerge;
-          }, null)
-        )
+          }, null),
+        ),
       );
     })
     .catch((error) => console.log(error));


### PR DESCRIPTION
Our styling-related props haven't always been so consistent, so let's tidy them up with a v1 release in mind & flag some as deprecated. 

Here's a quick overview of exisitng & changing style-related props based on various modes/functionalities:
- **Drawing**
  - `drawColor` (string) - fill automatically applied at 20% (used to be 10%)
  - ~`drawPointColor` (string)~ now deprecated - it's only possible to set a single `drawType` at a time anyways, so `drawColor` is sufficient
  - ~`drawFillColor` (string)~ now deprecated
  - `drawPointer` (enum)
- **Showing a center map marker** (based on lat,lng props _not_ geojson)
  - `markerColor` (string)
  - `markerImage` (enum)
- **Displaying GeoJSON data**
  - `geojsonColor` (string)
  - `geojsonFill` (boolean) - 20% if true
- **Showing OS Features at point**
  - `featureColor` (string)
  - `featureFill` (boolean) - 20% if true
  - ~`featureBorderNone` (string)~ now deprecated
  
Any other votes for deprecation or refactoring?