### PR TITLE
fix: update `featuresGeojsonChange` event to match new `geojsonChange` behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,10 +50,8 @@
         ariaLabelOlFixedOverlay="Interactive example map"
         zoom="20"
         maxZoom="23"
-        basemap="MapboxSatellite"
         drawMode
         drawMany
-        drawType="Polygon"
         osCopyright="© Crown copyright and database rights 2024 OS (0)100024857"
         osProxyEndpoint="https://api.editor.planx.dev/proxy/ordnance-survey"
       />

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -235,7 +235,7 @@ export class MyMap extends LitElement {
   staticMode = false;
 
   /**
-   * @deprecated - both `area.squareMetres` & `area.hectares` are carculated by defualt now in applicable `geojsonChange` events
+   * @deprecated - both `area.squareMetres` & `area.hectares` are calculated by default now in applicable `geojsonChange` events
    */
   @property({ type: String })
   areaUnit: AreaUnitEnum = "m2";

--- a/src/components/my-map/utils.ts
+++ b/src/components/my-map/utils.ts
@@ -13,25 +13,26 @@ import { ProjectionEnum } from "./projections";
 export type AreaUnitEnum = "m2" | "ha";
 
 /**
- * Calculate & format the area of a polygon
+ * Calculate the area of a polygon
  * @param polygon
  * @param unit - defaults to square metres ("m2"), or supports "ha" for hectares
- * @returns - the total area formatted with unit as a string
+ * @returns - the total area
  */
-export function formatArea(polygon: Geometry, unit: AreaUnitEnum) {
+export function calculateArea(
+  polygon: Geometry,
+  unit: AreaUnitEnum = "m2",
+): number {
   const area = getArea(polygon);
 
   const squareMetres = Math.round(area * 100) / 100;
-  const hectares = squareMetres / 10000; // 0.0001 hectares in 1 square metre
+  const hectares = squareMetres / 10000; // 1 square metre = 0.0001 hectare
 
-  let output;
-  if (unit === "m2") {
-    output = squareMetres + " m²";
-  } else if (unit === "ha") {
-    output = hectares + " ha";
+  switch (unit) {
+    case "m2":
+      return squareMetres;
+    case "ha":
+      return hectares;
   }
-
-  return output;
 }
 
 /**


### PR DESCRIPTION
Follows on from #466 

**Changes:**
- Similar to `drawMode` - the `clickFeatures` functionality dispatches geojson & area events which should stay consistent with recent changes we've made to event dispatching - so we're deprecating `featuresAreaChange` event and instead setting `"area"` directly on the `featuresGeojsonChange` event data "properties"
- Deprecates `areaUnit` prop and simply sets _both_ `"area.squareMetres"` and `"area.hectares"` anywhere we calculate the area (these field names & new number type are more consistent with ODP Schema too)