### PR TITLE
fix: set explicit z-index for drawing layer

### DIFF
--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -535,6 +535,7 @@ export class MyMap extends LitElement {
       }
 
       map.addLayer(drawingLayer);
+      drawingLayer.setZIndex(1001); // Ensure drawing layer is on top of Mapbox Satellite style
 
       if (!loadInitialDrawing) {
         map.addInteraction(draw);


### PR DESCRIPTION
Quick one-line fix for a bug that was occuring when `basemap="MapboxSatellite"` & `drawMode` was enabled ! 

Now drawn features are shown _on top of_ the basemap when they're completed (`geojsonChange` events confirmed they were still there, just beneath the satellite imagery later)