### PR TITLE
fix: increase `drawMany` label font size and default drawing point size

### DIFF
--- a/src/components/my-map/drawing.ts
+++ b/src/components/my-map/drawing.ts
@@ -69,14 +69,14 @@ function getVertices(drawColor: string) {
 function styleFeatureLabels(drawType: DrawTypeEnum, feature: FeatureLike) {
   return new Text({
     text: feature.get("label"),
-    font: "80px inherit",
+    font: "20px Source Sans Pro,sans-serif",
     placement: drawType === "Point" ? "line" : "point", // "point" placement is center point of polygon
     fill: new Fill({
       color: "#000",
     }),
     stroke: new Stroke({
       color: "#fff",
-      width: 3,
+      width: 4,
     }),
   });
 }
@@ -91,7 +91,7 @@ function configureDrawingLayerStyle(
     case "Point":
       return new Style({
         image: new Circle({
-          radius: 9,
+          radius: 12,
           fill: new Fill({ color: drawColor }),
         }),
         text: drawMany ? styleFeatureLabels(drawType, feature) : undefined,


### PR DESCRIPTION
After screenshots:
![Screenshot from 2024-08-29 12-37-21](https://github.com/user-attachments/assets/5e4b6171-9149-4dfd-ab65-4022a84483d0)
![Screenshot from 2024-08-29 12-35-56](https://github.com/user-attachments/assets/e549a239-4588-49c9-9790-3ad83460681f)
