### PR TITLE
feat: read color from `drawGeojsonData` properties if set

### DIFF
--- a/src/components/my-map/drawing.ts
+++ b/src/components/my-map/drawing.ts
@@ -87,6 +87,7 @@ function configureDrawingLayerStyle(
   drawMany: boolean,
   feature: FeatureLike,
 ) {
+  drawColor = feature.get("color") || drawColor;
   switch (drawType) {
     case "Point":
       return new Style({


### PR DESCRIPTION
Same functionality as `geojsonData` now ! 

If initial features are set to pre-populate the drawing layer, read the `color` property from `drawGeojsonData` if it's set, else default to the `drawColor` prop. Label text is already populated the same way.

Eg this map is produced by this sample data - I think this should enable us to highlight a specific feature based on the active tab in Map&Label 
![Screenshot from 2024-09-02 14-34-20](https://github.com/user-attachments/assets/490d9d9d-758c-4102-a263-6574484da751)
```js
const map = document.querySelector("my-map");
map.drawGeojsonData = {
      "type": "FeatureCollection",
      "features": [
        {
          "type": "Feature",
          "geometry": {
            "type": "Polygon",
            "coordinates": [
              [
                [
                  -0.12779689203071595,
                  51.507483251157424
                ],
                [
                  -0.12782371412086485,
                  51.50738892768874
                ],
                [
                  -0.1276533938484192,
                  51.50742148182832
                ],
                [
                  -0.12770033250617982,
                  51.50751079691233
                ],
                [
                  -0.12779689203071595,
                  51.507483251157424
                ]
              ]
            ]
          },
          "properties": {
            "label": "1",
            "area.squareMetres": 96.62,
            "area.hectares": 0.009662
          }
        },
        {
          "type": "Feature",
          "geometry": {
            "type": "Polygon",
            "coordinates": [
              [
                [
                  -0.12757292757797242,
                  51.50743650680798
                ],
                [
                  -0.12767887483406065,
                  51.50734385268785
                ],
                [
                  -0.127508554561615,
                  51.50728625678846
                ],
                [
                  -0.1274106539325714,
                  51.50737891102574
                ],
                [
                  -0.12757292757797242,
                  51.50743650680798
                ]
              ]
            ]
          },
          "properties": {
            "color": "#A020F0",
            "area.squareMetres": 163.75,
            "area.hectares": 0.016375
          }
        },
        {
          "type": "Feature",
          "geometry": {
            "type": "Polygon",
            "coordinates": [
              [
                [
                  -0.12785992394256593,
                  51.50737139852703
                ],
                [
                  -0.12772179017829893,
                  51.50731046376956
                ],
                [
                  -0.1279095448093414,
                  51.507263719242815
                ],
                [
                  -0.12803694973754884,
                  51.50730044708928
                ],
                [
                  -0.12785992394256593,
                  51.50737139852703
                ]
              ]
            ]
          },
          "properties": {
            "label": "3",
            "area.squareMetres": 128.67,
            "area.hectares": 0.012866999999999998
          }
        }
      ]
    };
```