### PR TITLE
fix: maintain drawing labels when modifying features

### DIFF
--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -554,7 +554,9 @@ export class MyMap extends LitElement {
 
         // Assign a label to each feature based on its' index
         sketches.forEach((sketch, i) => {
-          sketch.set("label", `${i + 1}`); // needs to be type string in order to be parsed by Style "Text"
+          // If this feature already exists and is only being modified, use its' current label, else use index (needs to be type string in order to be parsed by Style "Text")
+          const label = sketch.get("label") || `${i + 1}`;
+          sketch.set("label", label);
         });
 
         if (sketches.length > 0) {


### PR DESCRIPTION
Previously, when a feature was modified it's label would shift because internally it was moving to the last position in the drawing source. Now, keep labels on modify by checking if the "label" property already exists and only add new labels to new features.

Expect we might revisit this again when getting further into remove-one-at-a-time, but this fixes our known existing bug ! 

![chrome-capture-2024-8-2 (1)](https://github.com/user-attachments/assets/95a7c864-a583-41ed-becb-b5530bc9ad50)
