### PR TITLE
fix: ensure `drawMany` feature labels are incremental

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
         maxZoom="23"
         drawMode
         drawMany
+        drawType="Point"
         basemap="MapboxSatellite"
         showCentreMarker
         osCopyright="© Crown copyright and database rights 2024 OS (0)100024857"

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -561,9 +561,9 @@ export class MyMap extends LitElement {
         const sketches = drawingSource.getFeatures();
 
         // Assign a label to each feature based on its' index
-        sketches.forEach((sketch, i) => {
-          // If this feature already exists and is only being modified, use its' current label, else use index (needs to be type string in order to be parsed by Style "Text")
-          const label = sketch.get("label") || `${i + 1}`;
+        sketches.forEach((sketch) => {
+          // If this feature already exists and is only being modified, use its' current label, else use feature length (needs to be type string in order to be parsed by Style "Text")
+          const label = sketch.get("label") || `${sketches.length}`;
           sketch.set("label", label);
         });
 


### PR DESCRIPTION
Flagged while testing `drawMany` 

I honestly don't fully understand what was happening here, but my best guess is that is has to do with how OpenLayer's `change` event listens to more internal events than just adding features as we _see_ them on the map, therefore anything called in this block may be firing off more often than we expect? 

Setting the label based on the current length of all features, rather than an index of the one we're iterating over, seems to do the trick - labels are consistently incrementing by one now! 
![chrome-capture-2024-8-4 (1)](https://github.com/user-attachments/assets/466a24a6-da75-47ea-871d-92668f3d1aa5)