### PR TITLE
style: Improve legibility of dot labels

### DIFF
--- a/src/components/my-map/drawing.ts
+++ b/src/components/my-map/drawing.ts
@@ -69,14 +69,10 @@ function getVertices(drawColor: string) {
 function styleFeatureLabels(drawType: DrawTypeEnum, feature: FeatureLike) {
   return new Text({
     text: feature.get("label"),
-    font: "20px Source Sans Pro,sans-serif",
+    font: "18px Source Sans Pro,sans-serif",
     placement: drawType === "Point" ? "line" : "point", // "point" placement is center point of polygon
     fill: new Fill({
-      color: "#000",
-    }),
-    stroke: new Stroke({
       color: "#fff",
-      width: 4,
     }),
   });
 }
@@ -93,7 +89,11 @@ function configureDrawingLayerStyle(
       return new Style({
         image: new Circle({
           radius: 12,
-          fill: new Fill({ color: drawColor }),
+          fill: new Fill({ color: "#000" }),
+          stroke: new Stroke({
+            color: drawColor,
+            width: 2,
+          }),
         }),
         text: drawMany ? styleFeatureLabels(drawType, feature) : undefined,
       });

--- a/src/components/my-map/drawing.ts
+++ b/src/components/my-map/drawing.ts
@@ -67,13 +67,15 @@ function getVertices(drawColor: string) {
 }
 
 function styleFeatureLabels(drawType: DrawTypeEnum, feature: FeatureLike) {
+  const offset = -25;
   return new Text({
     text: feature.get("label"),
-    font: "18px Source Sans Pro,sans-serif",
+    font: "bold 19px Source Sans Pro,sans-serif",
     placement: drawType === "Point" ? "line" : "point", // "point" placement is center point of polygon
     fill: new Fill({
-      color: "#fff",
+      color: "#000",
     }),
+    offsetY: offset,
   });
 }
 
@@ -84,19 +86,40 @@ function configureDrawingLayerStyle(
   feature: FeatureLike,
 ) {
   drawColor = feature.get("color") || drawColor;
+
   switch (drawType) {
     case "Point":
-      return new Style({
-        image: new Circle({
-          radius: 12,
-          fill: new Fill({ color: "#000" }),
-          stroke: new Stroke({
-            color: drawColor,
-            width: 2,
+      return [
+        new Style({
+          image: new RegularShape({
+            points: 3,
+            radius: 10,
+            angle: Math.PI,
+            displacement: [0, 10],
+            fill: new Fill({
+              color: drawColor,
+            }),
           }),
         }),
-        text: drawMany ? styleFeatureLabels(drawType, feature) : undefined,
-      });
+        new Style({
+          image: new CircleStyle({
+            radius: 12,
+            fill: new Fill({
+              color: "#fff",
+            }),
+            stroke: new Stroke({
+              color: drawColor,
+              width: 2,
+            }),
+            displacement: [0, 25],
+          }),
+        }),
+        drawMany
+          ? new Style({
+              text: styleFeatureLabels(drawType, feature),
+            })
+          : undefined,
+      ];
     default:
       return [
         new Style({


### PR DESCRIPTION
## What does this PR do?

- Improves visibility of point labels by bringing in "map marker" style

**Preview (before vs after):**

![image](https://github.com/user-attachments/assets/7b6f41bb-120b-48dd-a98a-2fdeee7571fd)