### PR TITLE
style: Improve legibility of dot labels

### DIFF
--- a/src/components/my-map/drawing.ts
+++ b/src/components/my-map/drawing.ts
@@ -89,11 +89,11 @@ function configureDrawingLayerStyle(
     case "Point":
       return new Style({
         image: new Circle({
-          radius: 12,
+          radius: hideDrawLabels ? 10 : 12,
           fill: new Fill({ color: "#fff" }),
           stroke: new Stroke({
             color: drawColor,
-            width: 2,
+            width: hideDrawLabels ? 6 : 2,
           }),
         }),
         text:

--- a/src/components/my-map/drawing.ts
+++ b/src/components/my-map/drawing.ts
@@ -69,14 +69,10 @@ function getVertices(drawColor: string) {
 function styleFeatureLabels(drawType: DrawTypeEnum, feature: FeatureLike) {
   return new Text({
     text: feature.get("label"),
-    font: "20px Source Sans Pro,sans-serif",
+    font: "bold 19px Source Sans Pro,sans-serif",
     placement: drawType === "Point" ? "line" : "point", // "point" placement is center point of polygon
     fill: new Fill({
       color: "#000",
-    }),
-    stroke: new Stroke({
-      color: "#fff",
-      width: 4,
     }),
   });
 }
@@ -94,7 +90,11 @@ function configureDrawingLayerStyle(
       return new Style({
         image: new Circle({
           radius: 12,
-          fill: new Fill({ color: drawColor }),
+          fill: new Fill({ color: "#fff" }),
+          stroke: new Stroke({
+            color: drawColor,
+            width: 2,
+          }),
         }),
         text:
           drawMany && !hideDrawLabels


### PR DESCRIPTION
## What does this PR do?

Improves visibility of point labels by removing character stroke and keeping background/text colour constant (not dependent on custom colour selection).

**Preview (before vs after):**
![image](https://github.com/user-attachments/assets/b7b2269d-c501-48ec-b96b-2dfd44a06a68)
