### PR TITLE
fix: consistent point styles

### DIFF
--- a/src/components/my-map/drawing.ts
+++ b/src/components/my-map/drawing.ts
@@ -29,7 +29,7 @@ function configureDrawPointerImage(
       });
     case "dot":
       return new CircleStyle({
-        radius: 6,
+        radius: 10,
         fill: new Fill({
           color: drawColor,
         }),
@@ -89,11 +89,11 @@ function configureDrawingLayerStyle(
     case "Point":
       return new Style({
         image: new Circle({
-          radius: hideDrawLabels ? 10 : 12,
+          radius: drawMany && !hideDrawLabels ? 12 : 10,
           fill: new Fill({ color: "#fff" }),
           stroke: new Stroke({
             color: drawColor,
-            width: hideDrawLabels ? 6 : 2,
+            width: drawMany && !hideDrawLabels ? 2 : 6,
           }),
         }),
         text:

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -503,7 +503,7 @@ export class MyMap extends LitElement {
               : hexToRgba(featureColor, 0),
           }),
           image: new Circle({
-            radius: 9,
+            radius: 10,
             fill: new Fill({ color: featureColor }),
           }),
         });
@@ -706,7 +706,7 @@ export class MyMap extends LitElement {
     }
 
     const markerCircle = new Circle({
-      radius: 9,
+      radius: 10,
       fill: new Fill({ color: this.markerColor }),
     });
 


### PR DESCRIPTION
Quick follow-on to #507 

- Ensures drawing a _single_ point uses same style as `drawMany` with hidden labels
- Bumps radius of center marker & geojson data points to match drawing points