### PR TITLE
Remove polyfill.io links

### DIFF
--- a/src/components/address-autocomplete/index.ts
+++ b/src/components/address-autocomplete/index.ts
@@ -254,7 +254,6 @@ export class AddressAutocomplete extends LitElement {
       errorMessage = `No addresses found in postcode ${this.postcode}`;
 
     return html`
-      <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
       ${this._getErrorMessageContainer(errorMessage)}
       ${this._getAutocomplete(errorMessage)}
     `;

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -777,8 +777,7 @@ export class MyMap extends LitElement {
 
   // render the map
   render() {
-    return html`<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
-      <link rel="stylesheet" href="https://cdn.skypack.dev/ol@^6.6.1/ol.css" />
+    return html`<link rel="stylesheet" href="https://cdn.skypack.dev/ol@^6.6.1/ol.css" />
       <div
         id="${this.id}"
         class="map"

--- a/src/components/postcode-search/index.ts
+++ b/src/components/postcode-search/index.ts
@@ -102,8 +102,7 @@ export class PostcodeSearch extends LitElement {
   }
 
   render() {
-    return html`<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
-      <div class="govuk-form-group">
+    return html`<div class="govuk-form-group">
         ${this._makeLabel()}
         <div id="postcode-hint" class="govuk-hint">${this.hintText}</div>
         <p


### PR DESCRIPTION
The domain was sold to a Chinese company and no longer resolves. 
https://www.theregister.com/2024/06/25/polyfillio_china_crisis/