### PR TITLE
fix: output 4326 for lookup against planning.data.gov.uk API

### DIFF
--- a/src/components/geocode-autocomplete/index.ts
+++ b/src/components/geocode-autocomplete/index.ts
@@ -9,8 +9,9 @@ import { getServiceURL } from "../../lib/ordnanceSurvey";
 type Address = {
   LPI: {
     ADDRESS: string;
+    LAT: number;
+    LNG: number;
     MATCH: number;
-    UPRN: number;
   };
 };
 

--- a/src/components/geocode-autocomplete/index.ts
+++ b/src/components/geocode-autocomplete/index.ts
@@ -138,9 +138,10 @@ export class GeocodeAutocomplete extends LitElement {
     const params: Record<string, string> = {
       query: input,
       dataset: "LPI",
-      fq: "LPI_LOGICAL_STATUS_CODE:1",
       maxresults: "100",
       lr: "EN",
+      output_srs: "EPSG:4326",
+      fq: "LPI_LOGICAL_STATUS_CODE:1",
     };
 
     const url = getServiceURL({


### PR DESCRIPTION
- output 4326 coordinates

belatedly realizing we need to pass lat/lng to the next API here, so adding that to the output;

the BNG coordinates are still present in the output if those need to be used anywhere.