### PR TITLE
chore: update OS license number

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
           drawType="Point"
           basemap="MapboxSatellite"
           showCentreMarker
-          osCopyright="© Crown copyright and database rights 2024 OS (0)100024857"
+          osCopyright="© Crown copyright and database rights 2024 OS AC0000812160"
           osProxyEndpoint="https://api.editor.planx.dev/proxy/ordnance-survey"
         />
       </div>

--- a/src/components/my-map/docs/my-map-basic.doc.js
+++ b/src/components/my-map/docs/my-map-basic.doc.js
@@ -74,7 +74,7 @@ module.exports = {
     {
       name: "osCopyright",
       type: "String",
-      values: `© Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857 (default)`,
+      values: `© Crown copyright and database rights ${new Date().getFullYear()} OS AC0000812160 (default)`,
     },
     {
       name: "osVectorTileApiKey",

--- a/src/components/my-map/docs/my-map-proxy.doc.js
+++ b/src/components/my-map/docs/my-map-proxy.doc.js
@@ -74,7 +74,7 @@ module.exports = {
     {
       name: "osCopyright",
       type: "String",
-      values: `© Crown copyright and database rights ${new Date().getFullYear()} OS (0)100024857 (default)`,
+      values: `© Crown copyright and database rights ${new Date().getFullYear()} OS AC0000812160 (default)`,
     },
     {
       name: "osVectorTileApiKey",


### PR DESCRIPTION
We have a new OS API key (for `env.local` only) and with that a new default license number. Updating docs here to reflect!

See also:
- https://trello.com/c/ka4MISS4/3074-update-os-license-number
- https://github.com/theopensystemslab/planx-new/pull/5078