### PR TITLE
feat: add `showGeojsonDataLabels` prop

### DIFF
--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -14,7 +14,7 @@ import VectorTileLayer from "ol/layer/VectorTile";
 import Map from "ol/Map";
 import { ProjectionLike, transform, transformExtent } from "ol/proj";
 import { Vector as VectorSource, XYZ } from "ol/source";
-import { Circle, Fill, Icon, Stroke, Style } from "ol/style";
+import { Circle, Fill, Icon, Stroke, Style, Text } from "ol/style";
 import View from "ol/View";
 import {
   northArrowControl,
@@ -179,6 +179,9 @@ export class MyMap extends LitElement {
 
   @property({ type: Boolean })
   showGeojsonDataMarkers = false;
+
+  @property({ type: Boolean })
+  showGeojsonDataLabels = false;
 
   @property({ type: String })
   geojsonDataCopyright = "";
@@ -499,7 +502,11 @@ export class MyMap extends LitElement {
       source: geojsonSource,
       style: function (this: MyMap, feature: FeatureLike) {
         // Read color from geojson feature `properties` if set or fallback to prop
-        let featureColor = feature.get("color") || this.geojsonColor;
+        const featureColor = feature.get("color") || this.geojsonColor;
+
+        // Read label from geojson feature `properties` if set or fallback to empty string
+        const featureLabel = feature.get("label") || "";
+
         return new Style({
           stroke: new Stroke({
             color: featureColor,
@@ -511,8 +518,23 @@ export class MyMap extends LitElement {
               : hexToRgba(featureColor, 0),
           }),
           image: new Circle({
-            radius: 10,
-            fill: new Fill({ color: featureColor }),
+            radius: this.showGeojsonDataLabels ? 12 : 10,
+            fill: new Fill({
+              color: this.showGeojsonDataLabels ? "#fff" : featureColor,
+            }),
+            stroke: new Stroke({
+              color: featureColor,
+              width: this.showGeojsonDataLabels ? 2 : 6,
+            }),
+          }),
+          text: new Text({
+            text: this.showGeojsonDataLabels ? featureLabel : "",
+            font: "bold 19px Source Sans Pro,sans-serif",
+            placement:
+              feature.getGeometry()?.getType() === "Point" ? "line" : "point", // "point" placement is center point of polygon
+            fill: new Fill({
+              color: "#000",
+            }),
           }),
         });
       }.bind(this),


### PR DESCRIPTION
When rendering a static geojson `FeatureCollection` (eg output by `drawMode` + `drawMany`), we want the option to display feature labels! Labels will be "off" by default. Styles (label position, size, stroke & fill) match configs for the drawing vector layer.

Examples for various `drawType`: 
<img width="675" height="713" alt="Screenshot from 2025-09-08 16-01-13" src="https://github.com/user-attachments/assets/43151cfe-5912-47fe-8ace-689f5921fe89" />
<img width="672" height="708" alt="Screenshot from 2025-09-08 16-02-14" src="https://github.com/user-attachments/assets/685cfb46-9763-4303-84e6-1d603ed18205" />
