### PR TITLE
style: Geocode autocomplete

### DIFF
--- a/src/components/geocode-autocomplete/index.ts
+++ b/src/components/geocode-autocomplete/index.ts
@@ -15,7 +15,6 @@ type Address = {
   };
 };
 
-type ArrowStyleEnum = "default" | "light";
 type LabelStyleEnum = "responsive" | "static";
 
 function debounce(
@@ -59,9 +58,6 @@ export class GeocodeAutocomplete extends LitElement {
   osProxyEndpoint = "";
 
   @property({ type: String })
-  arrowStyle: ArrowStyleEnum = "default";
-
-  @property({ type: String })
   labelStyle: LabelStyleEnum = "responsive";
 
   // internal reactive state
@@ -87,10 +83,6 @@ export class GeocodeAutocomplete extends LitElement {
     super.disconnectedCallback();
   }
 
-  _getLightDropdownArrow() {
-    return '<svg class="autocomplete__dropdown-arrow-down" style="height: 17px;" viewBox="0 0 512 512" ><path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9  c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3  z"/></svg>';
-  }
-
   // called after the initial render
   firstUpdated() {
     // https://github.com/alphagov/accessible-autocomplete
@@ -112,8 +104,6 @@ export class GeocodeAutocomplete extends LitElement {
       showAllValues: true,
       displayMenu: "overlay",
       minLength: 3,
-      dropdownArrow:
-        this.arrowStyle === "light" ? this._getLightDropdownArrow : undefined,
       tNoResults: () => (this._isLoading ? `Loading...` : `No results found`),
       tStatusQueryTooShort: (minQueryLength: number) =>
         `Type at least ${minQueryLength} characters for search results`,

--- a/src/components/geocode-autocomplete/styles.scss
+++ b/src/components/geocode-autocomplete/styles.scss
@@ -7,39 +7,32 @@
     arial,
     sans-serif
   );
-  $font-size: var(--autocomplete__input__font-size, 19px);
-  $input-height: var(--autocomplete__input__height, 35px);
-  $arrow-down-z-index: var(--autocomplete__dropdown-arrow-down__z-index, 1);
+  $input-font-size: var(--autocomplete__input__font-size, 19px);
+  $input-height: var(--autocomplete__input__height, 48px);
+  $input-max-width: var(--autocomplete__input__max-width, 900px);
+  $input-padding: var(--autocomplete__input__padding, 8px);
+  $label-font-size: var(--autocomplete__label__font-size, 1em);
+  $label-margin-bottom: var(--autocomplete__label__margin-bottom, 0.5em);
 
-  .govuk-label {
-    font-family: $font-family;
-  }
-
+  .govuk-label,
   .govuk-label--static {
-    font-size: var(--autocomplete__label__font-size, 19px);
+    font-family: $font-family;
+    font-size: $label-font-size;
+    margin-bottom: $label-margin-bottom;
   }
 
   .autocomplete__input {
     font-family: $font-family;
-    font-size: $font-size;
+    font-size: $input-font-size;
     height: $input-height;
-    padding: var(--autocomplete__input__padding, 5px 34px 5px 5px);
-    // Ensure arrow is visible on white background, but behind the input so the click interaction works
-    // https://github.com/alphagov/accessible-autocomplete/issues/351
-    z-index: calc($arrow-down-z-index + 1);
-  }
-
-  .autocomplete__dropdown-arrow-down {
-    z-index: $arrow-down-z-index;
-    // Ensure the down arrow is vertically centred
-    $arrow-down-height: 17px;
-    top: calc(($input-height - $arrow-down-height) / 2);
+    padding: $input-padding;
+    max-width: $input-max-width;
   }
 
   .autocomplete__option {
     font-family: $font-family;
-    font-size: $font-size;
-    padding: var(--autocomplete__option__padding, 5px);
+    font-size: $input-font-size;
+    padding: var(--autocomplete__option__padding, 5px 8px);
     border-bottom: var(
       --autocomplete__option__border-bottom,
       solid 1px #b1b4b6
@@ -49,10 +42,10 @@
   .autocomplete__option--focused,
   .autocomplete__option:hover,
   .autocomplete__option--focused & .autocomplete__option:hover {
-    border-color: var(--autocomplete__option__hover-border-color, #1d70b8);
+    border-color: var(--autocomplete__option__hover-border-color, #1a1b1b);
     background-color: var(
       --autocomplete__option__hover-background-color,
-      #1d70b8
+      #1a1b1b
     );
   }
 


### PR DESCRIPTION
## What does this PR do?

- Adds styles to `geocode-autocomplete` web component, with CSS custom properties to allow overrides in the Local Planning Service repo
- Removes chevron down icon - this is not required as the autocomplete options appear automatically, unlike the postcode lookup a user click isn't needed to view options (it also takes no effect)

(no image preview as I can't get it running locally)