### PR TITLE
feat: optionally show a search bar when drawing on an OS basemap to position the map view

### DIFF
--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -72,6 +72,9 @@ export class MyMap extends LitElement {
   @property({ type: String })
   id = "map";
 
+  @property({ type: Boolean })
+  showOSSearch = false;
+
   @property({ type: String })
   dataTestId = "map-test-id";
 
@@ -288,7 +291,7 @@ export class MyMap extends LitElement {
   }
 
   // runs after the initial render
-  firstUpdated() {
+  async firstUpdated() {
     const target = this.renderRoot.querySelector(`#${this.id}`) as HTMLElement;
 
     const isUsingOS = Boolean(this.osApiKey || this.osProxyEndpoint);
@@ -785,6 +788,41 @@ export class MyMap extends LitElement {
       });
     }
 
+    // Duplicated logic in render()
+    const showSearch =
+      this.showOSSearch &&
+      this.drawMode &&
+      ["OSVectorTile", "OSRaster"].includes(this.basemap) &&
+      (Boolean(this.osApiKey) || Boolean(this.osProxyEndpoint));
+
+    if (showSearch) {
+      const search = this.renderRoot?.querySelector("geocode-autocomplete");
+      if (search) {
+        // Give the browser a chance to paint
+        //  Ref https://lit.dev/docs/v1/components/events/#add-event-listeners-after-first-paint
+        await new Promise((r) => setTimeout(r, 0));
+
+        search.addEventListener(
+          "addressSelection",
+          ({ detail: address }: any) => {
+            console.debug("searched", { detail: address });
+            const searchedAddress = address?.address?.LPI;
+            const newCenterCoordinate = transform(
+              [searchedAddress.LNG, searchedAddress.LAT],
+              "EPSG:4326", // LPI output srs
+              "EPSG:3857",
+            );
+
+            // TODO handle validation here before recentering (eg is searched point within clip extent)
+            //   error wrapper on geocode autocomplete?? or popup/toast on map?
+
+            map.getView().setCenter(newCenterCoordinate);
+            map.getView().setZoom(20);
+          },
+        );
+      }
+    }
+
     // Add an aria-label to the overlay canvas for accessibility
     const olCanvas = this.renderRoot?.querySelector("canvas.ol-fixedoverlay");
     olCanvas?.setAttribute("aria-label", this.ariaLabelOlFixedOverlay);
@@ -799,19 +837,50 @@ export class MyMap extends LitElement {
 
   // render the map
   render() {
-    return html`<link
-        rel="stylesheet"
-        href="https://cdn.skypack.dev/ol@^6.6.1/ol.css"
-      />
-      <div
-        id="${this.id}"
-        class="map"
-        role="${this.staticMode && !this.collapseAttributions
-          ? "presentation"
-          : "application"}"
-        tabindex="${this.staticMode && !this.collapseAttributions ? -1 : 0}"
-        data-testid="${this.dataTestId}"
-      />`;
+    // Duplicated logic in firstUpdated()
+    const showSearch =
+      this.showOSSearch &&
+      this.drawMode &&
+      ["OSVectorTile", "OSRaster"].includes(this.basemap) &&
+      (Boolean(this.osApiKey) || Boolean(this.osProxyEndpoint));
+
+    return showSearch
+      ? html` <div style="margin-bottom: 1em; background-color: white">
+            <geocode-autocomplete
+              id="geocode-autocomplete"
+              arrowStyle="light"
+              labelStyle="static"
+              label="Search for an address to position the map"
+              osApiKey="${this.osApiKey}"
+              osProxyEndpoint="${this.osProxyEndpoint}"
+            />
+          </div>
+          <link
+            rel="stylesheet"
+            href="https://cdn.skypack.dev/ol@^6.6.1/ol.css"
+          />
+          <div
+            id="${this.id}"
+            class="map"
+            role="${this.staticMode && !this.collapseAttributions
+              ? "presentation"
+              : "application"}"
+            tabindex="${this.staticMode && !this.collapseAttributions ? -1 : 0}"
+            data-testid="${this.dataTestId}"
+          />`
+      : html` <link
+            rel="stylesheet"
+            href="https://cdn.skypack.dev/ol@^6.6.1/ol.css"
+          />
+          <div
+            id="${this.id}"
+            class="map"
+            role="${this.staticMode && !this.collapseAttributions
+              ? "presentation"
+              : "application"}"
+            tabindex="${this.staticMode && !this.collapseAttributions ? -1 : 0}"
+            data-testid="${this.dataTestId}"
+          />`;
   }
 
   // unmount the map

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -1,5 +1,5 @@
 import { html, LitElement, unsafeCSS } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import apply from "ol-mapbox-style";
 import { defaults as defaultControls, ScaleLine } from "ol/control";
 import { containsCoordinate, Extent } from "ol/extent";
@@ -277,6 +277,13 @@ export class MyMap extends LitElement {
 
   @property({ type: String })
   ariaLabelOlFixedOverlay = "";
+
+  // internal reactive state
+  @state()
+  private _showSearch: boolean = false;
+
+  @state()
+  private _searchError: string | undefined = undefined;
 
   // set class property (map doesn't require any reactivity using @state)
   map?: Map;
@@ -785,14 +792,7 @@ export class MyMap extends LitElement {
       });
     }
 
-    // Duplicated logic in render()
-    const showSearch =
-      this.showOSSearch &&
-      this.drawMode &&
-      ["OSVectorTile", "OSRaster"].includes(this.basemap) &&
-      (Boolean(this.osApiKey) || Boolean(this.osProxyEndpoint));
-
-    if (showSearch) {
+    if (this._showSearch) {
       const search = this.renderRoot?.querySelector("geocode-autocomplete");
       if (search) {
         // Give the browser a chance to paint
@@ -813,21 +813,16 @@ export class MyMap extends LitElement {
             // Validate that the searched point is within the clip extent of the map viewport
             const searchedPointWithinClip =
               clipExtent && containsCoordinate(clipExtent, newCenterCoordinate);
-            let searchedPointNotWithinClipError: string | undefined;
-
             if (searchedPointWithinClip) {
+              // Navigate to the searched address point
               map.getView().setCenter(newCenterCoordinate);
               map.getView().setZoom(20);
             } else {
-              searchedPointNotWithinClipError =
+              // Show an error
+              this._searchError =
                 "Selected address not within map view extent, try another.";
+              this._showSearchError();
             }
-
-            // TODO render autcomplete error message
-            console.log(
-              searchedPointWithinClip,
-              searchedPointNotWithinClipError,
-            );
           },
         );
       }
@@ -845,25 +840,48 @@ export class MyMap extends LitElement {
     }, 500);
   }
 
+  _showSearchError() {
+    const errorEl: HTMLElement | null | undefined =
+      this.shadowRoot?.querySelector(`#geocode-autocomplete-error`);
+
+    // display "none" ensures always present in DOM, which means role="status" will work for screenreaders
+    if (errorEl) errorEl.style.display = "none";
+    if (errorEl && this._searchError) errorEl.style.display = "";
+  }
+
   // render the map
   render() {
-    // Duplicated logic in firstUpdated()
-    const showSearch =
+    this._showSearch =
       this.showOSSearch &&
       this.drawMode &&
       ["OSVectorTile", "OSRaster"].includes(this.basemap) &&
       (Boolean(this.osApiKey) || Boolean(this.osProxyEndpoint));
 
-    return showSearch
-      ? html` <div style="margin-bottom: 1em; background-color: white">
-            <geocode-autocomplete
-              id="geocode-autocomplete"
-              arrowStyle="light"
-              labelStyle="static"
-              label="Search for an address to position the map"
-              osApiKey="${this.osApiKey}"
-              osProxyEndpoint="${this.osProxyEndpoint}"
-            />
+    return this._showSearch
+      ? html` <div
+            id="error-message-container"
+            class="${this._searchError ? "govuk-warning-text" : ""}"
+            role="status"
+          >
+            <div
+              id="geocode-autocomplete-error"
+              class="govuk-error-message"
+              style="display:none"
+              role="status"
+            >
+              <span class="govuk-visually-hidden">Error:</span>
+              ${this._searchError}
+            </div>
+            <div style="margin-bottom: 1em; background-color: white">
+              <geocode-autocomplete
+                id="geocode-autocomplete"
+                arrowStyle="light"
+                labelStyle="static"
+                label="Search for an address to position the map"
+                osApiKey="${this.osApiKey}"
+                osProxyEndpoint="${this.osProxyEndpoint}"
+              />
+            </div>
           </div>
           <link
             rel="stylesheet"

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -2,8 +2,10 @@ import { html, LitElement, unsafeCSS } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import apply from "ol-mapbox-style";
 import { defaults as defaultControls, ScaleLine } from "ol/control";
+import { containsCoordinate } from "ol/extent";
 import { FeatureLike } from "ol/Feature";
 import { GeoJSON } from "ol/format";
+import { GeoJSONFeature, GeoJSONFeatureCollection } from "ol/format/GeoJSON";
 import { Geometry, Point } from "ol/geom";
 import { Feature } from "ol/index";
 import { defaults as defaultInteractions } from "ol/interaction";
@@ -58,7 +60,6 @@ import {
   hexToRgba,
   makeGeoJSON,
 } from "./utils";
-import { GeoJSONFeatureCollection } from "ol/format/GeoJSON";
 
 type MarkerImageEnum = "circle" | "pin";
 type ResetControlImageEnum = "unicode" | "trash";
@@ -272,11 +273,13 @@ export class MyMap extends LitElement {
   collapseAttributions = false;
 
   @property({ type: Object })
-  clipGeojsonData = {
+  clipGeojsonData: GeoJSONFeature = {
     type: "Feature",
     geometry: {
+      type: "Polygon",
       coordinates: [],
     },
+    properties: {},
   };
 
   @property({ type: String })
@@ -340,11 +343,9 @@ export class MyMap extends LitElement {
       "EPSG:3857",
     );
 
-    const clipFeature =
-      this.clipGeojsonData.geometry?.coordinates?.length > 0 &&
-      new GeoJSON().readFeature(this.clipGeojsonData, {
-        featureProjection: "EPSG:3857",
-      });
+    const clipFeature = new GeoJSON().readFeature(this.clipGeojsonData, {
+      featureProjection: "EPSG:3857",
+    });
     const clipExtent =
       clipFeature &&
       !Array.isArray(clipFeature) &&
@@ -813,11 +814,24 @@ export class MyMap extends LitElement {
               "EPSG:3857",
             );
 
-            // TODO handle validation here before recentering (eg is searched point within clip extent)
-            //   error wrapper on geocode autocomplete?? or popup/toast on map?
+            // Validate that the searched point is within the clip extent of the map viewport
+            const searchedPointWithinClip =
+              clipExtent && containsCoordinate(clipExtent, newCenterCoordinate);
+            let searchedPointNotWithinClipError: string | undefined;
 
-            map.getView().setCenter(newCenterCoordinate);
-            map.getView().setZoom(20);
+            if (searchedPointWithinClip) {
+              map.getView().setCenter(newCenterCoordinate);
+              map.getView().setZoom(20);
+            } else {
+              searchedPointNotWithinClipError =
+                "Selected address not within map view extent, try another.";
+            }
+
+            // TODO render autcomplete error message
+            console.log(
+              searchedPointWithinClip,
+              searchedPointNotWithinClipError,
+            );
           },
         );
       }

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -2,7 +2,7 @@ import { html, LitElement, unsafeCSS } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import apply from "ol-mapbox-style";
 import { defaults as defaultControls, ScaleLine } from "ol/control";
-import { containsCoordinate } from "ol/extent";
+import { containsCoordinate, Extent } from "ol/extent";
 import { FeatureLike } from "ol/Feature";
 import { GeoJSON } from "ol/format";
 import { GeoJSONFeature, GeoJSONFeatureCollection } from "ol/format/GeoJSON";
@@ -273,14 +273,7 @@ export class MyMap extends LitElement {
   collapseAttributions = false;
 
   @property({ type: Object })
-  clipGeojsonData: GeoJSONFeature = {
-    type: "Feature",
-    geometry: {
-      type: "Polygon",
-      coordinates: [],
-    },
-    properties: {},
-  };
+  clipGeojsonData: GeoJSONFeature | undefined = undefined;
 
   @property({ type: String })
   ariaLabelOlFixedOverlay = "";
@@ -343,27 +336,30 @@ export class MyMap extends LitElement {
       "EPSG:3857",
     );
 
-    const clipFeature = new GeoJSON().readFeature(this.clipGeojsonData, {
-      featureProjection: "EPSG:3857",
-    });
-    const clipExtent =
-      clipFeature &&
-      !Array.isArray(clipFeature) &&
-      clipFeature.getGeometry()?.getExtent();
+    // Define a clip extent for the map viewport
+    let clipExtent: Extent | undefined;
+    if (this.clipGeojsonData) {
+      const clipFeature = new GeoJSON().readFeature(this.clipGeojsonData, {
+        featureProjection: "EPSG:3857",
+      });
+      if (clipFeature && !Array.isArray(clipFeature)) {
+        clipExtent = clipFeature.getGeometry()?.getExtent();
+      }
+    } else {
+      // Fallback to UK boundary if no user prop
+      clipExtent = transformExtent(
+        [-10.76418, 49.528423, 1.9134116, 61.331151],
+        "EPSG:4326",
+        "EPSG:3857",
+      );
+    }
 
     const map = new Map({
       target,
       layers: basemapLayers,
       view: new View({
         projection: "EPSG:3857",
-        extent: clipExtent
-          ? clipExtent
-          : transformExtent(
-              // UK Boundary
-              [-10.76418, 49.528423, 1.9134116, 61.331151],
-              "EPSG:4326",
-              "EPSG:3857",
-            ),
+        extent: clipExtent,
         minZoom: this.minZoom,
         maxZoom: this.maxZoom,
         center: centerCoordinate,

--- a/src/components/my-map/my-map.stories.ts
+++ b/src/components/my-map/my-map.stories.ts
@@ -521,15 +521,15 @@ export const DrawModeGeoJSONOutput: Story = {
  */
 export const DrawModeWithSearch: Story = {
   name: "Drawing: draw mode with search",
-  // TOOD ! Mock realistic "propose a new address" props
   render: () => `
-      <my-map
-      id="draw-mode"
+    <my-map
+      id="draw-mode-with-search"
       zoom="20"
       maxZoom="23"
       drawMode
-      showOSSearch
       drawPointer="dot"
+      showOSSearch
+      basemap="OSVectorTile"
       osVectorTilesApiKey="${osApiKey}"
     </my-map>`,
 };

--- a/src/components/my-map/my-map.stories.ts
+++ b/src/components/my-map/my-map.stories.ts
@@ -234,6 +234,16 @@ const meta: Meta = {
         defaultValue: { summary: '"m2"' },
       },
     },
+    showOSSearch: {
+      description:
+        "Show a search bar (<geocode-autocomplete />) to position (re-center) the map at a known address when drawing on an OS Basemap",
+      control: "boolean",
+      table: {
+        category: "Drawing",
+        type: { summary: "Boolean" },
+        defaultValue: { summary: "false" },
+      },
+    },
     // ── GeoJSON ──────────────────────────────────────────────────
     geojsonData: {
       description:
@@ -504,6 +514,24 @@ export const DrawModeGeoJSONOutput: Story = {
       },
     );
   },
+};
+
+/**
+ * Show a search bar to position (re-center) the map when drawing on an OS basemap.
+ */
+export const DrawModeWithSearch: Story = {
+  name: "Drawing: draw mode with search",
+  // TOOD ! Mock realistic "propose a new address" props
+  render: () => `
+      <my-map
+      id="draw-mode"
+      zoom="20"
+      maxZoom="23"
+      drawMode
+      showOSSearch
+      drawPointer="dot"
+      osVectorTilesApiKey="${osApiKey}"
+    </my-map>`,
 };
 
 // ---------------------------------------------------------------------------

--- a/src/components/my-map/snapping.ts
+++ b/src/components/my-map/snapping.ts
@@ -1,4 +1,5 @@
 import { Feature } from "ol";
+import { Extent } from "ol/extent";
 import { Geometry } from "ol/geom";
 import Point from "ol/geom/Point";
 import { Vector as VectorLayer } from "ol/layer";
@@ -36,7 +37,7 @@ export const pointsLayer = new VectorLayer({
  */
 export function getSnapPointsFromVectorTiles(
   basemap: VectorTileLayer,
-  extent: number[],
+  extent: Extent,
 ) {
   const points: number[] =
     basemap &&

--- a/src/components/my-map/styles.scss
+++ b/src/components/my-map/styles.scss
@@ -1,3 +1,5 @@
+@import "govuk-frontend/dist/govuk/index";
+
 $gov-uk-yellow: #ffdd00;
 $planx-blue: #0010a4;
 $planx-dark-grey: #2c2c2c;


### PR DESCRIPTION
**Changes / how this works**
- Add a prop `showOSSearch` which will render the geocode autocomplete search component above the map
- The searched address is used to _position_ the map only, it does not inherently place the draw point (because may be using `drawMany`, draw `polygon` etc)
- The geocode autocomplete will inherently return _all_ OS addresses throughout the UK, but an error will be thrown if the map uses a small clip extent (eg Lambeth's boundary) and you search an address outside of it (eg in Buckinghamshire)

**Next steps**
- Merge this and publish a new alpha/@next release of this package https://github.com/theopensystemslab/map/blob/main/CHANGELOG.md
- Bring into planx-new feature branch and hookup + test on FindProperty's "Propose a new address" route

**Prior art**
Originally started here https://github.com/theopensystemslab/planx-new/pull/6455, but ultimately couldn't hack two-way data flow and Lit's `update` life cycle so opted for this "composite component" approach directly within `render` and controlled via map props instead :heavy_plus_sign: 