### PR TITLE
fix: correct height and error styles for map with `showOSSearch` enabled

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,8 @@
           drawMode
           drawMany
           drawType="Point"
-          basemap="MapboxSatellite"
+          basemap="OSVectorTile"
+          showOSSearch
           showCentreMarker
           osCopyright="© Crown copyright and database rights 2024 OS AC0000812160"
           osProxyEndpoint="https://api.editor.planx.dev/proxy/ordnance-survey"

--- a/src/components/my-map/index.ts
+++ b/src/components/my-map/index.ts
@@ -803,6 +803,10 @@ export class MyMap extends LitElement {
           "addressSelection",
           ({ detail: address }: any) => {
             console.debug("searched", { detail: address });
+            // Clear any pre-existing errors on new search
+            this._searchError = "";
+            this._showSearchError();
+
             const searchedAddress = address?.address?.LPI;
             const newCenterCoordinate = transform(
               [searchedAddress.LNG, searchedAddress.LAT],
@@ -820,7 +824,7 @@ export class MyMap extends LitElement {
             } else {
               // Show an error
               this._searchError =
-                "Selected address not within map view extent, try another.";
+                "Selected address not within map view extent, try another";
               this._showSearchError();
             }
           },
@@ -847,6 +851,15 @@ export class MyMap extends LitElement {
     // display "none" ensures always present in DOM, which means role="status" will work for screenreaders
     if (errorEl) errorEl.style.display = "none";
     if (errorEl && this._searchError) errorEl.style.display = "";
+    if (errorEl && !this._searchError) errorEl.style.display = "none";
+
+    // additionally set error style on outer div to match govuk style
+    const errorWrapperEl: HTMLElement | null | undefined =
+      this.shadowRoot?.querySelector(`.govuk-form-group`);
+    if (errorWrapperEl && this._searchError)
+      errorWrapperEl.classList.add("govuk-form-group--error");
+    if (errorWrapperEl && !this._searchError)
+      errorWrapperEl.classList.remove("govuk-form-group--error");
   }
 
   // render the map
@@ -858,35 +871,37 @@ export class MyMap extends LitElement {
       (Boolean(this.osApiKey) || Boolean(this.osProxyEndpoint));
 
     return this._showSearch
-      ? html` <div
-            id="error-message-container"
-            class="${this._searchError ? "govuk-warning-text" : ""}"
-            role="status"
-          >
-            <div
-              id="geocode-autocomplete-error"
-              class="govuk-error-message"
-              style="display:none"
-              role="status"
-            >
-              <span class="govuk-visually-hidden">Error:</span>
-              ${this._searchError}
-            </div>
-            <div style="margin-bottom: 1em; background-color: white">
-              <geocode-autocomplete
-                id="geocode-autocomplete"
-                arrowStyle="light"
-                labelStyle="static"
-                label="Search for an address to position the map"
-                osApiKey="${this.osApiKey}"
-                osProxyEndpoint="${this.osProxyEndpoint}"
-              />
-            </div>
-          </div>
-          <link
+      ? html` <link
             rel="stylesheet"
             href="https://cdn.skypack.dev/ol@^6.6.1/ol.css"
           />
+          <div class="govuk-form-group">
+            <div
+              id="error-message-container"
+              class="${this._searchError ? "govuk-warning-text" : ""}"
+              role="status"
+            >
+              <div
+                id="geocode-autocomplete-error"
+                class="govuk-error-message"
+                style="display:none"
+                role="status"
+              >
+                <span class="govuk-visually-hidden">Error:</span>
+                ${this._searchError}
+              </div>
+              <div style="background-color: white">
+                <geocode-autocomplete
+                  id="geocode-autocomplete"
+                  arrowStyle="light"
+                  labelStyle="static"
+                  label="Search for an address to position the map (optional)"
+                  osApiKey="${this.osApiKey}"
+                  osProxyEndpoint="${this.osProxyEndpoint}"
+                />
+              </div>
+            </div>
+          </div>
           <div
             id="${this.id}"
             class="map"

--- a/src/components/my-map/styles.scss
+++ b/src/components/my-map/styles.scss
@@ -6,20 +6,21 @@ $planx-dark-grey: #2c2c2c;
 
 // default map size, can be overwritten with CSS
 :host {
-  display: block;
+  display: flex;
+  flex-direction: column;
   width: 650px;
-  height: 650px;
+  height: auto;
   position: relative;
 }
 
 .map {
-  height: 100%;
+  width: 100%;
+  height: 650px;
   opacity: 0;
   transition: opacity 0.25s;
   overflow: hidden;
   border: #000000 solid 0.15em;
 }
-
 .map:focus {
   outline: $gov-uk-yellow solid 0.25em;
 }


### PR DESCRIPTION
Fixes two noticable issues when using in planx:
- [x] Autocomplete search error message
  - Missing govuk-style left border when visible
  - Not clearing on address selection _change_ 
- [x] Overall height when search + map are grouped 
  - `map` class requires height to render (currently 100% with + without search); this means search + map are > 100% and overlapping other content like planx's `MapFooter`
  - To test / recreate: `pnpm dev` from this branch, see index.html elements overlapping here when map has search visible 
<img width="254" height="155" alt="image" src="https://github.com/user-attachments/assets/cbcd1759-ea24-4f50-9bb8-8f755bf295d4" />
