### PR TITLE
feat: Improve styling options for Geocode component

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,13 @@
         --postcode__input__padding: 30px 10px;
         --postcode__input__height: 60px;
       }
+
+      my-map {
+        --autocomplete__font-family: "Courier New";
+        --autocomplete__error__font-weight: 900;
+        --autocomplete__input__max-width: 500px;
+        --govuk-error-colour: hotpink;
+      }
     </style> -->
   </head>
 

--- a/src/components/geocode-autocomplete/styles.scss
+++ b/src/components/geocode-autocomplete/styles.scss
@@ -19,6 +19,7 @@
     font-family: $font-family;
     font-size: $label-font-size;
     margin-bottom: $label-margin-bottom;
+    max-width: $input-max-width;
   }
 
   .autocomplete__input {
@@ -51,5 +52,6 @@
 
   .autocomplete__menu {
     max-height: var(--autocomplete__menu__max-height, 342px);
+    max-width: calc($input-max-width - 4px);
   }
 }

--- a/src/components/my-map/styles.scss
+++ b/src/components/my-map/styles.scss
@@ -25,6 +25,17 @@ $planx-dark-grey: #2c2c2c;
   outline: $gov-uk-yellow solid 0.25em;
 }
 
+.govuk-warning-text {
+  margin-bottom: 0px;
+  max-width: var(--autocomplete__input__max-width);
+  padding-bottom: 0px;
+}
+
+.govuk-error-message {
+  font-family: var(--autocomplete__font-family);
+  font-weight: var(--autocomplete__font-weight);
+}
+
 .ol-control button {
   border-radius: 0 !important;
   background-color: $planx-dark-grey !important;


### PR DESCRIPTION
This PR allows us to style the `<my-map showOSSearch />` component to allow the following - 
 - custom max-width
 - custom font (overwriting default GDS Transport")

It also removes bottom margin and padding which was growing the error wrapper larger than the input.
 
 
<img width="757" height="447" alt="image" src="https://github.com/user-attachments/assets/b1fc7b21-4028-4e97-b218-d0e1efce4152" />
